### PR TITLE
Update FHIR dependencies to version 0.12.0-beta.4 to include snapshotted profiles

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -25,8 +25,8 @@ publisher:
 # use cases, the value can be an object with keys for id, uri, and version.
 
 dependencies:
-   nictiz.fhir.nl.r4.nl-core: 0.12.0-beta.1
-   nictiz.fhir.nl.r4.zib2020: 0.12.0-beta.1
+   nictiz.fhir.nl.r4.nl-core: 0.12.0-beta.4
+   nictiz.fhir.nl.r4.zib2020: 0.12.0-beta.4
 
 #   hl7.fhir.us.mcode:
 #     id: mcode


### PR DESCRIPTION
Bump nictiz.fhir.nl.r4.nl-core and nictiz.fhir.nl.r4.zib2020 dependencies from 0.12.0-beta.1 to 0.12.0-beta.4 in sushi-config.yaml.