### PR TITLE
Comment out displayLanguage parameter in Parameters.fsh

### DIFF
--- a/input/fsh/Parameters.fsh
+++ b/input/fsh/Parameters.fsh
@@ -2,7 +2,7 @@ Instance: expansion
 InstanceOf: Parameters
 Description: "SNOMED CT Netherlands expansion parameter"
 Usage: #definition
-* parameter[+].name = "displayLanguage"
-* parameter[=].valueCode = urn:ietf:bcp:47#nl
+//* parameter[+].name = "displayLanguage"
+//* parameter[=].valueCode = urn:ietf:bcp:47#nl
 * parameter[+].name = "system-version"
 * parameter[=].valueCanonical = "http://snomed.info/sct|http://snomed.info/sct/11000146104"


### PR DESCRIPTION
The displayLanguage parameter lines have been commented out in the SNOMED CT Netherlands expansion Parameters instance. This may be to disable language-specific display settings while retaining the configuration for future reference.