### PR TITLE
Add script to populate questionnaire item prefixes

### DIFF
--- a/input/resources/Questionnaire-ACP-zib2020.json
+++ b/input/resources/Questionnaire-ACP-zib2020.json
@@ -190,7 +190,8 @@
           "item": [
             {
               "linkId": "30",
-              "text": "a) Naam wettelijk vertegenwoordiger",
+              "prefix": "a)",
+              "text": "Naam wettelijk vertegenwoordiger",
               "type": "group",
               "repeats": false,
               "item": [
@@ -219,7 +220,8 @@
             },
             {
               "linkId": "39",
-              "text": "b) Contactgegevens wettelijk vertegenwoordiger",
+              "prefix": "b)",
+              "text": "Contactgegevens wettelijk vertegenwoordiger",
               "type": "group",
               "repeats": false,
               "item": [
@@ -359,7 +361,8 @@
             },
             {
               "linkId": "982",
-              "text": "c) Relatie tot patiënt (1)",
+              "prefix": "c)",
+              "text": "Relatie tot patiënt (1)",
               "type": "choice",
               "required": false,
               "repeats": true,
@@ -456,7 +459,8 @@
             },
             {
               "linkId": "983",
-              "text": "c) Relatie tot patiënt (2)",
+              "prefix": "c)",
+              "text": "Relatie tot patiënt (2)",
               "type": "choice",
               "required": false,
               "repeats": false,
@@ -598,7 +602,8 @@
             {
               "type": "choice",
               "linkId": "984",
-              "text": "d) Is de wettelijk vertegenwoordiger ook de eerste contactpersoon?",
+              "prefix": "d)",
+              "text": "Is de wettelijk vertegenwoordiger ook de eerste contactpersoon?",
               "required": false,
               "repeats": false,
               "answerOption": [
@@ -642,7 +647,8 @@
               ],
               "type": "group",
               "linkId": "53",
-              "text": "e) Naam eerste contactpersoon",
+              "prefix": "e)",
+              "text": "Naam eerste contactpersoon",
               "enableWhen": [
                 {
                   "question": "984",
@@ -793,7 +799,8 @@
               ],
               "type": "group",
               "linkId": "61",
-              "text": "f) Contactgegevens eerste contactpersoon",
+              "prefix": "f)",
+              "text": "Contactgegevens eerste contactpersoon",
               "enableWhen": [
                 {
                   "question": "984",
@@ -872,7 +879,8 @@
                   "code": "OTH"
                 }
               ],
-              "text": "g) Relatie tot patiënt",
+              "prefix": "g)",
+              "text": "Relatie tot patiënt",
               "enableWhen": [
                 {
                   "question": "984",
@@ -968,7 +976,8 @@
       ],
       "type": "group",
       "linkId": "26",
-      "text": "1. Wilsbekwaamheid & Wettelijke vertegenwoordiging",
+      "prefix": "1.",
+      "text": "Wilsbekwaamheid & Wettelijke vertegenwoordiging",
       "repeats": false
     },
     {
@@ -1196,12 +1205,14 @@
       ],
       "type": "group",
       "linkId": "78",
-      "text": "2 Gesprek gevoerd in bijzijn van",
+      "prefix": "2",
+      "text": "Gesprek gevoerd in bijzijn van",
       "repeats": false
     },
     {
       "linkId": "586",
-      "text": "3. Belangrijkste overeengekomen doel van medisch beleid",
+      "prefix": "3.",
+      "text": "Belangrijkste overeengekomen doel van medisch beleid",
       "type": "group",
       "repeats": false,
       "item": [
@@ -1270,13 +1281,15 @@
     },
     {
       "linkId": "83",
-      "text": "4. Behandelgrenzen",
+      "prefix": "4.",
+      "text": "Behandelgrenzen",
       "type": "group",
       "repeats": false,
       "item": [
         {
           "linkId": "1409",
-          "text": "a) Reanimatie",
+          "prefix": "a)",
+          "text": "Reanimatie",
           "type": "group",
           "repeats": false,
           "item": [
@@ -1406,7 +1419,8 @@
         },
         {
           "linkId": "1411",
-          "text": "b) Kunstmatige invasieve beademing",
+          "prefix": "b)",
+          "text": "Kunstmatige invasieve beademing",
           "type": "group",
           "repeats": false,
           "item": [
@@ -1522,7 +1536,8 @@
         },
         {
           "linkId": "1413",
-          "text": "c) Opname op intensive care",
+          "prefix": "c)",
+          "text": "Opname op intensive care",
           "type": "group",
           "repeats": false,
           "item": [
@@ -1638,7 +1653,8 @@
         },
         {
           "linkId": "1415",
-          "text": "d) Opname in ziekenhuis",
+          "prefix": "d)",
+          "text": "Opname in ziekenhuis",
           "type": "group",
           "repeats": false,
           "item": [
@@ -1754,7 +1770,8 @@
         },
         {
           "linkId": "1417",
-          "text": "e) Behandeling met antibiotica",
+          "prefix": "e)",
+          "text": "Behandeling met antibiotica",
           "type": "group",
           "repeats": false,
           "item": [
@@ -1870,7 +1887,8 @@
         },
         {
           "linkId": "1419",
-          "text": "f) Toediening van een bloedproduct",
+          "prefix": "f)",
+          "text": "Toediening van een bloedproduct",
           "type": "group",
           "repeats": false,
           "item": [
@@ -2086,7 +2104,8 @@
           ],
           "type": "group",
           "linkId": "1421",
-          "text": "g) Overige behandelgrenzen",
+          "prefix": "g)",
+          "text": "Overige behandelgrenzen",
           "repeats": false
         },
         {
@@ -2138,7 +2157,8 @@
           ],
           "type": "choice",
           "linkId": "1006",
-          "text": "h) Heeft de patiënt een ICD?",
+          "prefix": "h)",
+          "text": "Heeft de patiënt een ICD?",
           "required": false,
           "repeats": false,
           "answerOption": [
@@ -2263,7 +2283,8 @@
           ],
           "type": "group",
           "linkId": "1425",
-          "text": "i) Is er een afspraak over het moment van uitzetten ICD?",
+          "prefix": "i)",
+          "text": "Is er een afspraak over het moment van uitzetten ICD?",
           "enableWhen": [
             {
               "question": "1006",
@@ -2281,13 +2302,15 @@
     },
     {
       "linkId": "107",
-      "text": "5. Behandelwensen",
+      "prefix": "5.",
+      "text": "Behandelwensen",
       "type": "group",
       "repeats": false,
       "item": [
         {
           "linkId": "1427",
-          "text": "a) Wat zouden zorgverleners, volgens de patiënt, moeten weten om goede zorg te kunnen verlenen? Heeft deze patiënt specifieke wensen met betrekking tot zijn zorg? (incl. culturele/religieuze/sociale/spirituele aspecten) ",
+          "prefix": "a)",
+          "text": "Wat zouden zorgverleners, volgens de patiënt, moeten weten om goede zorg te kunnen verlenen? Heeft deze patiënt specifieke wensen met betrekking tot zijn zorg? (incl. culturele/religieuze/sociale/spirituele aspecten) ",
           "type": "group",
           "repeats": false,
           "item": [
@@ -2326,7 +2349,8 @@
         },
         {
           "linkId": "1429",
-          "text": "b) Gewenste plek van overlijden",
+          "prefix": "b)",
+          "text": "Gewenste plek van overlijden",
           "type": "group",
           "repeats": false,
           "item": [
@@ -2423,7 +2447,8 @@
         },
         {
           "linkId": "1431",
-          "text": "c) Euthanasie standpunt",
+          "prefix": "c)",
+          "text": "Euthanasie standpunt",
           "type": "group",
           "repeats": false,
           "item": [
@@ -2506,7 +2531,8 @@
         },
         {
           "linkId": "1433",
-          "text": "d) Keuze orgaandonatie vastgelegd in donorregister?",
+          "prefix": "d)",
+          "text": "Keuze orgaandonatie vastgelegd in donorregister?",
           "type": "group",
           "repeats": false,
           "item": [
@@ -2570,7 +2596,8 @@
     },
     {
       "linkId": "598",
-      "text": "6. Wat verder nog belangrijk is",
+      "prefix": "6.",
+      "text": "Wat verder nog belangrijk is",
       "type": "group",
       "repeats": false,
       "item": [
@@ -2635,7 +2662,8 @@
           ],
           "type": "choice",
           "linkId": "1197",
-          "text": "a) Heeft de patiënt eerder behandelafspraken vastgelegd?",
+          "prefix": "a)",
+          "text": "Heeft de patiënt eerder behandelafspraken vastgelegd?",
           "required": false,
           "repeats": false,
           "answerOption": [
@@ -2664,7 +2692,8 @@
         },
         {
           "linkId": "1199",
-          "text": "b) Staan in eerder vastgelegde behandelafspraken andere wensen dan nu in deze verklaring?",
+          "prefix": "b)",
+          "text": "Staan in eerder vastgelegde behandelafspraken andere wensen dan nu in deze verklaring?",
           "type": "choice",
           "enableWhen": [
             {
@@ -2706,18 +2735,21 @@
       ],
       "type": "group",
       "linkId": "115",
-      "text": "7. Eerder vastgelegde behandelwensen",
+      "prefix": "7.",
+      "text": "Eerder vastgelegde behandelwensen",
       "repeats": false
     },
     {
       "linkId": "119",
-      "text": "8. Informatie delen",
+      "prefix": "8.",
+      "text": "Informatie delen",
       "type": "group",
       "repeats": false,
       "item": [
         {
           "linkId": "1200",
-          "text": "a) Heeft u patient geïnformeerd over eigen verantwoordelijkheid om deze behandelafspraken met naasten te bespreken?",
+          "prefix": "a)",
+          "text": "Heeft u patient geïnformeerd over eigen verantwoordelijkheid om deze behandelafspraken met naasten te bespreken?",
           "type": "choice",
           "required": false,
           "repeats": false,
@@ -2744,7 +2776,8 @@
         },
         {
           "linkId": "1201",
-          "text": "b) Patiënt gaat akkoord met het delen van deze behandelafspraken met andere betrokken hulpverleners",
+          "prefix": "b)",
+          "text": "Patiënt gaat akkoord met het delen van deze behandelafspraken met andere betrokken hulpverleners",
           "type": "choice",
           "required": false,
           "repeats": false,

--- a/util/questionnaire_item_prefix_populator.py
+++ b/util/questionnaire_item_prefix_populator.py
@@ -1,0 +1,230 @@
+"""
+Questionnaire Item Prefix Populator
+
+This script is used to populate the prefix of questionnaire items based on the prefix in item.text examples. 
+It is intended to be run as a post-processing step after generating the FHIR Questionnaire.
+
+The script will:
+1. Loop through the input/resources files and find the questionnaire resources
+2. Transform/move the item.text values that start with a prefix like "a)", "b)", "1.", "2." etc 
+3. Populate the item.prefix field with that value and remove it from the item.text field
+
+Examples of text that will be processed:
+- "text": "c) Relatie tot patiënt (2)" -> prefix: "c)", text: "Relatie tot patiënt (2)"
+- "text": "d) Is de wettelijk vertegenwoordiger ook de eerste contactpersoon?" -> prefix: "d)", text: "Is de wettelijk vertegenwoordiger ook de eerste contactpersoon?"
+- "text": "1. Wilsbekwaamheid & Wettelijke vertegenwoordiging" -> prefix: "1.", text: "Wilsbekwaamheid & Wettelijke vertegenwoordiging"
+- "text": "2 Gesprek gevoerd in bijzijn van" -> prefix: "2", text: "Gesprek gevoerd in bijzijn van"
+- "text": "3. Belangrijkste overeengekomen doel van medisch beleid" -> prefix: "3.", text: "Belangrijkste overeengekomen doel van medisch beleid"
+
+Usage:
+    python questionnaire_item_prefix_populator.py [--dry-run] [--input-dir INPUT_DIR]
+"""
+
+import json
+import re
+import argparse
+from pathlib import Path
+import shutil
+from typing import Dict, Any, Tuple, Optional
+
+
+def extract_prefix_from_text(text: str) -> Tuple[Optional[str], str]:
+    """
+    Extract prefix from text if it starts with a recognized pattern.
+    
+    Args:
+        text: The original text string
+        
+    Returns:
+        Tuple of (prefix, remaining_text) or (None, original_text) if no prefix found
+    """
+    if not isinstance(text, str) or not text.strip():
+        return None, text
+    
+    # Pattern for letter followed by ) - e.g., "a)", "b)", "c)"
+    letter_pattern = re.compile(r'^([a-zA-Z]\))\s*(.*)$')
+    match = letter_pattern.match(text)
+    if match:
+        return match.group(1), match.group(2)
+    
+    # Pattern for number followed by . - e.g., "1.", "2.", "3."
+    number_dot_pattern = re.compile(r'^(\d+\.)\s*(.*)$')
+    match = number_dot_pattern.match(text)
+    if match:
+        return match.group(1), match.group(2)
+    
+    # Pattern for number without dot - e.g., "1 ", "2 "
+    number_space_pattern = re.compile(r'^(\d+)\s+(.*)$')
+    match = number_space_pattern.match(text)
+    if match:
+        return match.group(1), match.group(2)
+    
+    # Pattern for number followed by ) - e.g., "1)", "2)"
+    number_paren_pattern = re.compile(r'^(\d+\))\s*(.*)$')
+    match = number_paren_pattern.match(text)
+    if match:
+        return match.group(1), match.group(2)
+    
+    return None, text
+
+
+def process_questionnaire_item(item: Dict[str, Any]) -> int:
+    """
+    Process a single questionnaire item and its children recursively.
+    
+    Args:
+        item: A questionnaire item dictionary
+        
+    Returns:
+        Number of items modified
+    """
+    modifications = 0
+    
+    # Process current item's text
+    if 'text' in item and isinstance(item['text'], str):
+        prefix, remaining_text = extract_prefix_from_text(item['text'])
+        if prefix:
+            # Create a new ordered dictionary to ensure prefix comes before text
+            new_item = {}
+            
+            # Copy all fields in order, inserting prefix before text
+            for key, value in item.items():
+                if key == 'text':
+                    # Insert prefix before text
+                    new_item['prefix'] = prefix
+                    new_item['text'] = remaining_text
+                elif key != 'prefix':  # Skip existing prefix if any
+                    new_item[key] = value
+            
+            # Update the original item with the new ordered content
+            item.clear()
+            item.update(new_item)
+            
+            modifications += 1
+            print(f"  Modified item: prefix='{prefix}', text='{remaining_text[:50]}...'")
+    
+    # Process child items recursively
+    if 'item' in item and isinstance(item['item'], list):
+        for child_item in item['item']:
+            modifications += process_questionnaire_item(child_item)
+    
+    return modifications
+
+
+def process_questionnaire_file(file_path: Path, dry_run: bool = False) -> bool:
+    """
+    Process a single questionnaire JSON file.
+    
+    Args:
+        file_path: Path to the questionnaire JSON file
+        dry_run: If True, don't write changes to file
+        
+    Returns:
+        True if file was modified, False otherwise
+    """
+    try:
+        # Read the JSON file
+        with open(file_path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+        
+        # Check if this is a Questionnaire resource
+        if not isinstance(data, dict) or data.get('resourceType') != 'Questionnaire':
+            print(f"Skipping {file_path.name}: Not a Questionnaire resource")
+            return False
+        
+        print(f"Processing {file_path.name}...")
+        
+        # Process all top-level items
+        total_modifications = 0
+        if 'item' in data and isinstance(data['item'], list):
+            for item in data['item']:
+                total_modifications += process_questionnaire_item(item)
+        
+        if total_modifications > 0:
+            print(f"  Total modifications: {total_modifications}")
+            
+            if not dry_run:
+                # Create backup
+                backup_path = file_path.with_suffix(file_path.suffix + '.backup')
+                shutil.copy2(file_path, backup_path)
+                print(f"  Created backup: {backup_path.name}")
+                
+                # Write modified data back to file
+                with open(file_path, 'w', encoding='utf-8') as f:
+                    json.dump(data, f, indent=2, ensure_ascii=False)
+                print(f"  Updated {file_path.name}")
+            else:
+                print(f"  [DRY RUN] Would modify {file_path.name}")
+            
+            return True
+        else:
+            print(f"  No modifications needed for {file_path.name}")
+            return False
+            
+    except Exception as e:
+        print(f"Error processing {file_path.name}: {e}")
+        return False
+
+
+def main():
+    """Main function to process questionnaire files."""
+    parser = argparse.ArgumentParser(
+        description="Populate questionnaire item prefixes from text content",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__
+    )
+    parser.add_argument(
+        '--dry-run', 
+        action='store_true', 
+        help='Show what would be changed without modifying files'
+    )
+    parser.add_argument(
+        '--input-dir', 
+        type=Path, 
+        default='input/resources',
+        help='Directory containing questionnaire JSON files (default: input/resources)'
+    )
+    
+    args = parser.parse_args()
+    
+    # Resolve input directory path
+    input_dir = args.input_dir
+    if not input_dir.is_absolute():
+        # Assume relative to script directory's parent (repo root)
+        script_dir = Path(__file__).parent
+        repo_root = script_dir.parent
+        input_dir = repo_root / input_dir
+    
+    if not input_dir.exists():
+        print(f"Error: Input directory does not exist: {input_dir}")
+        return 1
+    
+    print(f"Looking for questionnaire files in: {input_dir}")
+    if args.dry_run:
+        print("DRY RUN MODE - No files will be modified")
+    print()
+    
+    # Find and process questionnaire JSON files
+    questionnaire_files = list(input_dir.glob("Questionnaire*.json"))
+    
+    if not questionnaire_files:
+        print("No questionnaire files found matching pattern 'Questionnaire*.json'")
+        return 0
+    
+    modified_count = 0
+    for file_path in questionnaire_files:
+        if process_questionnaire_file(file_path, args.dry_run):
+            modified_count += 1
+        print()  # Empty line between files
+    
+    print(f"Summary: {modified_count}/{len(questionnaire_files)} files modified")
+    
+    if args.dry_run and modified_count > 0:
+        print("Run without --dry-run to apply changes")
+    
+    return 0
+
+
+if __name__ == '__main__':
+    exit(main())
+


### PR DESCRIPTION
Introduces util/questionnaire_item_prefix_populator.py, a script that extracts prefix patterns (e.g., 'a)', '1.') from item.text fields in FHIR Questionnaire JSON files and moves them to the item.prefix field. Updates Questionnaire-ACP-zib2020.json to use the new prefix field, improving structure and clarity of questionnaire items.