### PR TITLE
Update MedicalPolicyGoal identity and replace search on description with search on category

### DIFF
--- a/input/fsh/CapabilityStatement.fsh
+++ b/input/fsh/CapabilityStatement.fsh
@@ -117,7 +117,7 @@ Usage: #definition
       * url = $CapExpectation
       * valueCode = #SHOULD
     * type = #Goal
-    * supportedProfile[0] = "https://api.iknl.nl/docs/pzp/r4/StructureDefinition/ACP-Medical-Policy-Goal"
+    * supportedProfile[0] = "https://api.iknl.nl/docs/pzp/r4/StructureDefinition/ACP-MedicalPolicyGoal"
       * extension
         * url = $CapExpectation
         * valueCode = #SHOULD 
@@ -462,7 +462,7 @@ Usage: #definition
       * url = $CapExpectation
       * valueCode = #SHALL
     * type = #Goal
-    * supportedProfile[0] = "https://api.iknl.nl/docs/pzp/r4/StructureDefinition/ACP-Medical-Policy-Goal"
+    * supportedProfile[0] = "https://api.iknl.nl/docs/pzp/r4/StructureDefinition/ACP-MedicalPolicyGoal"
       * extension
         * url = $CapExpectation
         * valueCode = #SHOULD 

--- a/input/fsh/Goal.fsh
+++ b/input/fsh/Goal.fsh
@@ -1,6 +1,6 @@
 Profile: ACPMedicalPolicyGoal
 Parent: Goal
-Id: ACP-Medical-Policy-Goal
+Id: ACP-MedicalPolicyGoal
 Title: "ACP Medical Policy Goal"
 Description: "The primary, agreed-upon goal of a patient's medical treatment policy. Based on Goal resource."
 * insert MetaRules
@@ -27,7 +27,7 @@ Target: "https://decor.nictiz.nl/exist/apps/api/dataset/2.16.840.1.113883.2.4.3.
 * note.text -> "598" "[Toelichting]"
 
 
-Instance: ACP-Medical-Policy-Goal-Pat1
+Instance: ACP-MedicalPolicyGoal-Pat1
 InstanceOf: ACPMedicalPolicyGoal
 Title: "ACP Medical Policy Goal - Pat 1"
 Usage: #example

--- a/input/includes/mappings.md
+++ b/input/includes/mappings.md
@@ -163,11 +163,11 @@ This table provides an overview of all dataset elements that are mapped to FHIR 
 | 566 | &emsp;&emsp;Titels | RelatedPerson (<a href="StructureDefinition-ACP-ContactPerson.html">ACPContactPerson</a>) | `name[nameInformation].suffix`  |
 | 588 | &emsp;Rol | RelatedPerson (<a href="StructureDefinition-ACP-ContactPerson.html">ACPContactPerson</a>) | `relationship[role]`  |
 | 589 | &emsp;Relatie | RelatedPerson (<a href="StructureDefinition-ACP-ContactPerson.html">ACPContactPerson</a>) | `relationship[relationship]`  |
-| 590 | Belangrijkste doel van behandeling ([Meting]) | Goal (<a href="StructureDefinition-ACP-Medical-Policy-Goal.html">ACPMedicalPolicyGoal</a>) | ``  |
-| 591 | &emsp;Belangrijkste doel van behandeling ([MetingNaam]) | Goal (<a href="StructureDefinition-ACP-Medical-Policy-Goal.html">ACPMedicalPolicyGoal</a>) | ``  |
-| 592 | &emsp;Doel ([MetingWaarde]) | Goal (<a href="StructureDefinition-ACP-Medical-Policy-Goal.html">ACPMedicalPolicyGoal</a>) | `description`  |
-| 596 | &emsp;[MeetDatumBeginTijd] | Goal (<a href="StructureDefinition-ACP-Medical-Policy-Goal.html">ACPMedicalPolicyGoal</a>) | `startDate`  |
-| 598 | &emsp;[Toelichting] | Goal (<a href="StructureDefinition-ACP-Medical-Policy-Goal.html">ACPMedicalPolicyGoal</a>) | `note.text`  |
+| 590 | Belangrijkste doel van behandeling ([Meting]) | Goal (<a href="StructureDefinition-ACP-MedicalPolicyGoal.html">ACPMedicalPolicyGoal</a>) | ``  |
+| 591 | &emsp;Belangrijkste doel van behandeling ([MetingNaam]) | Goal (<a href="StructureDefinition-ACP-MedicalPolicyGoal.html">ACPMedicalPolicyGoal</a>) | ``  |
+| 592 | &emsp;Doel ([MetingWaarde]) | Goal (<a href="StructureDefinition-ACP-MedicalPolicyGoal.html">ACPMedicalPolicyGoal</a>) | `description`  |
+| 596 | &emsp;[MeetDatumBeginTijd] | Goal (<a href="StructureDefinition-ACP-MedicalPolicyGoal.html">ACPMedicalPolicyGoal</a>) | `startDate`  |
+| 598 | &emsp;[Toelichting] | Goal (<a href="StructureDefinition-ACP-MedicalPolicyGoal.html">ACPMedicalPolicyGoal</a>) | `note.text`  |
 | 602 | Behandelgrens (BehandelAanwijzing2) | Consent (<a href="StructureDefinition-ACP-TreatmentDirective.html">ACPTreatmentDirective</a>) | ``  |
 | 603 | &emsp;BehandelBesluit | Consent (<a href="StructureDefinition-ACP-TreatmentDirective.html">ACPTreatmentDirective</a>) | `provision.type`  |
 | 604 | &emsp;Behandeling | Consent (<a href="StructureDefinition-ACP-TreatmentDirective.html">ACPTreatmentDirective</a>) | `provision.code`  |

--- a/input/pagecontent/data-exchange.md
+++ b/input/pagecontent/data-exchange.md
@@ -64,7 +64,7 @@ The below listed search requests show how all the ACP agreements, procedural inf
     * B) Retrieves `Encounter` resources that list an ACP procedure as their reason, and includes the referenced resources in the result. Request A is generally preferred because `Encounter.patient` may not always be present; if absent, it indicates the patient was not involved in the Encounter. Using request A ensures these cases are included as well.
 2. Retrieves `Consent` resources for Treatment Directives and includes the agreement parties (Patient, ContactPersons, and HealthProfessionals).
 3. Retrieves `Consent` resources for Advance Directives and includes the representatives (ContactPersons).
-4. Retrieves `Goal` resources related to ACP based on the `Goal.category`.
+4. Retrieves `Goal` resources related to advance care planning.
 5. Retrieves `Observation` resources related to specific wishes and plans, as defined by the profiles in the Implementation Guide.
 6. Retrieves `DeviceUseStatement` resources for devices representing an ICD, and includes the corresponding `Device` resource.
 7. Retrieves `CommunicationRequest` resources representing all communication requests related to the ACP procedure.

--- a/input/pagecontent/data-exchange.md
+++ b/input/pagecontent/data-exchange.md
@@ -64,16 +64,12 @@ The below listed search requests show how all the ACP agreements, procedural inf
     * B) Retrieves `Encounter` resources that list an ACP procedure as their reason, and includes the referenced resources in the result. Request A is generally preferred because `Encounter.patient` may not always be present; if absent, it indicates the patient was not involved in the Encounter. Using request A ensures these cases are included as well.
 2. Retrieves `Consent` resources for Treatment Directives and includes the agreement parties (Patient, ContactPersons, and HealthProfessionals).
 3. Retrieves `Consent` resources for Advance Directives and includes the representatives (ContactPersons).
-4. Retrieves `Goal` resources with a Medical Policy Goal code in the `Goal.description`.
+4. Retrieves `Goal` resources related to ACP based on the `Goal.category`.
 5. Retrieves `Observation` resources related to specific wishes and plans, as defined by the profiles in the Implementation Guide.
 6. Retrieves `DeviceUseStatement` resources for devices representing an ICD, and includes the corresponding `Device` resource.
 7. Retrieves `CommunicationRequest` resources representing all communication requests related to the ACP procedure.
 
 #### Advanced Search Parameters Supported
-
-Custom search parameters:
-* The `description` parameter allows searching on `Goal.description`. This search parameter is defined from R5 onwards. The parameter definition can be found in the <a href="https://hl7.org/fhir/searchparameter-registry.html#:~:text=Goal.%E2%80%8Bcategory-,description,-token">Search Parameter Registry</a> and be applied for this version.
-
 The queries above use several search parameter types and modifiers:
 * `_include`: Returns referenced resources in the same `Bundle`, reducing the need for additional API calls.
 * `in`: A modifier that enables searching against a ValueSet. In the client requests above, it checks if the device type is included in the specified ValueSet of ICD products.

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -208,7 +208,7 @@ groups:
     description: These are ACP profiles based on FHIR core resources.
     resources:
     - StructureDefinition/ACP-InformRelativesRequest
-    - StructureDefinition/ACP-Medical-Policy-Goal
+    - StructureDefinition/ACP-MedicalPolicyGoal
     - StructureDefinition/ACP-OrganDonationChoiceRegistration
     - StructureDefinition/ACP-PositionRegardingEuthanasia
     - StructureDefinition/ACP-PreferredPlaceOfDeath


### PR DESCRIPTION
- The text on the data exchange page is rewritten based on the change in the search query for goals. This was based on description and is now based on goal.category. Therefore we don't use an extension of the search parameters of the goal resource.
- The ID of the goal resource for ACP is changed as well.

Closes #90 