### PR TITLE
Remove item 'code' fields and add script to do so #113

### DIFF
--- a/input/resources/Questionnaire-ACP-zib2020.json
+++ b/input/resources/Questionnaire-ACP-zib2020.json
@@ -15,12 +15,6 @@
     {
       "type": "dateTime",
       "linkId": "963",
-      "code": [
-        {
-          "system": "http://snomed.info/sct",
-          "code": "439771001"
-        }
-      ],
       "text": "Datum van invullen",
       "required": false,
       "repeats": false
@@ -177,12 +171,7 @@
               "text": "Toelichting",
               "type": "string",
               "required": false,
-              "repeats": false,
-              "code": [
-                {
-                  "code": "48767-8"
-                }
-              ]
+              "repeats": false
             }
           ]
         },
@@ -310,12 +299,7 @@
                       "text": "Toelichting",
                       "type": "string",
                       "required": false,
-                      "repeats": false,
-                      "code": [
-                        {
-                          "code": "48767-8"
-                        }
-                      ]
+                      "repeats": false
                     }
                   ]
                 },
@@ -429,32 +413,6 @@
                   "required": false,
                   "repeats": false
                 }
-              ],
-              "code": [
-                {
-                  "system": "urn:oid:2.16.840.1.113883.2.4.3.11.22.472",
-                  "code": "01"
-                },
-                {
-                  "system": "urn:oid:2.16.840.1.113883.2.4.3.11.22.472",
-                  "code": "24"
-                },
-                {
-                  "system": "urn:oid:2.16.840.1.113883.2.4.3.11.22.472",
-                  "code": "03"
-                },
-                {
-                  "system": "urn:oid:2.16.840.1.113883.2.4.3.11.22.472",
-                  "code": "15"
-                },
-                {
-                  "system": "http://snomed.info/sct",
-                  "code": "310141000146103"
-                },
-                {
-                  "system": "urn:oid:2.16.840.1.113883.2.4.3.11.22.472",
-                  "code": "09"
-                }
               ]
             },
             {
@@ -554,48 +512,6 @@
                   "enableBehavior": "any",
                   "required": false,
                   "repeats": false
-                }
-              ],
-              "code": [
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
-                  "code": "HUSB"
-                },
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
-                  "code": "WIFE"
-                },
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
-                  "code": "DOMPART"
-                },
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
-                  "code": "FTH"
-                },
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
-                  "code": "MTH"
-                },
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
-                  "code": "SONC"
-                },
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
-                  "code": "DAUC"
-                },
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
-                  "code": "BRO"
-                },
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
-                  "code": "SIS"
-                },
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
-                  "code": "OTH"
                 }
               ]
             },
@@ -745,12 +661,7 @@
                       "text": "Toelichting",
                       "type": "string",
                       "required": false,
-                      "repeats": false,
-                      "code": [
-                        {
-                          "code": "48767-8"
-                        }
-                      ]
+                      "repeats": false
                     }
                   ],
                   "type": "group",
@@ -831,12 +742,6 @@
                 }
               ],
               "linkId": "1644",
-              "code": [
-                {
-                  "system": "urn:oid:2.16.840.1.113883.2.4.3.11.22.472",
-                  "code": "01"
-                }
-              ],
               "text": "Rol",
               "enableWhen": [
                 {
@@ -886,48 +791,6 @@
               ],
               "type": "choice",
               "linkId": "995",
-              "code": [
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
-                  "code": "HUSB"
-                },
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
-                  "code": "WIFE"
-                },
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
-                  "code": "DOMPART"
-                },
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
-                  "code": "FTH"
-                },
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
-                  "code": "MTH"
-                },
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
-                  "code": "SONC"
-                },
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
-                  "code": "DAUC"
-                },
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
-                  "code": "BRO"
-                },
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
-                  "code": "SIS"
-                },
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
-                  "code": "OTH"
-                }
-              ],
               "prefix": "g)",
               "text": "Relatie tot patiënt",
               "enableWhen": [
@@ -1090,24 +953,6 @@
               "required": false,
               "repeats": false
             }
-          ],
-          "code": [
-            {
-              "system": "urn:oid:2.16.840.1.113883.2.4.3.11.22.472",
-              "code": "03"
-            },
-            {
-              "system": "urn:oid:2.16.840.1.113883.2.4.3.11.22.472",
-              "code": "15"
-            },
-            {
-              "system": "http://snomed.info/sct",
-              "code": "310141000146103"
-            },
-            {
-              "system": "urn:oid:2.16.840.1.113883.2.4.3.11.22.472",
-              "code": "09"
-            }
           ]
         },
         {
@@ -1207,48 +1052,6 @@
               "required": false,
               "repeats": false
             }
-          ],
-          "code": [
-            {
-              "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
-              "code": "HUSB"
-            },
-            {
-              "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
-              "code": "WIFE"
-            },
-            {
-              "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
-              "code": "DOMPART"
-            },
-            {
-              "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
-              "code": "FTH"
-            },
-            {
-              "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
-              "code": "MTH"
-            },
-            {
-              "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
-              "code": "SONC"
-            },
-            {
-              "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
-              "code": "DAUC"
-            },
-            {
-              "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
-              "code": "BRO"
-            },
-            {
-              "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
-              "code": "SIS"
-            },
-            {
-              "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
-              "code": "OTH"
-            }
           ]
         }
       ],
@@ -1318,12 +1121,6 @@
                 "display": "Nog onbekend"
               }
             }
-          ],
-          "code": [
-            {
-              "system": "http://snomed.info/sct",
-              "code": "441742003"
-            }
           ]
         }
       ]
@@ -1359,12 +1156,6 @@
                 }
               ],
               "linkId": "1410",
-              "code": [
-                {
-                  "system": "http://snomed.info/sct",
-                  "code": "363589002"
-                }
-              ],
               "text": "Behandeling",
               "required": false,
               "repeats": false,
@@ -1405,31 +1196,11 @@
                   "text": "Toelichting",
                   "type": "string",
                   "required": false,
-                  "repeats": false,
-                  "code": [
-                    {
-                      "code": "48767-8"
-                    }
-                  ]
+                  "repeats": false
                 }
               ],
               "type": "choice",
               "linkId": "1386",
-              "code": [
-                {
-                  "code": "0"
-                },
-                {
-                  "code": "1"
-                },
-                {
-                  "code": "2"
-                },
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
-                  "code": "UNK"
-                }
-              ],
               "text": "BehandelBesluit",
               "required": false,
               "repeats": false,
@@ -1476,12 +1247,6 @@
             {
               "type": "choice",
               "linkId": "1412",
-              "code": [
-                {
-                  "system": "http://snomed.info/sct",
-                  "code": "363589002"
-                }
-              ],
               "text": "Behandeling",
               "required": false,
               "repeats": false,
@@ -1557,27 +1322,7 @@
                   "text": "Toelichting",
                   "type": "string",
                   "required": false,
-                  "repeats": false,
-                  "code": [
-                    {
-                      "code": "48767-8"
-                    }
-                  ]
-                }
-              ],
-              "code": [
-                {
-                  "code": "0"
-                },
-                {
-                  "code": "1"
-                },
-                {
-                  "code": "2"
-                },
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
-                  "code": "UNK"
+                  "repeats": false
                 }
               ]
             }
@@ -1593,12 +1338,6 @@
             {
               "type": "choice",
               "linkId": "1414",
-              "code": [
-                {
-                  "system": "http://snomed.info/sct",
-                  "code": "363589002"
-                }
-              ],
               "text": "Behandeling",
               "required": false,
               "repeats": false,
@@ -1674,27 +1413,7 @@
                   "text": "Toelichting",
                   "type": "string",
                   "required": false,
-                  "repeats": false,
-                  "code": [
-                    {
-                      "code": "48767-8"
-                    }
-                  ]
-                }
-              ],
-              "code": [
-                {
-                  "code": "0"
-                },
-                {
-                  "code": "1"
-                },
-                {
-                  "code": "2"
-                },
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
-                  "code": "UNK"
+                  "repeats": false
                 }
               ]
             }
@@ -1710,12 +1429,6 @@
             {
               "type": "choice",
               "linkId": "1416",
-              "code": [
-                {
-                  "system": "http://snomed.info/sct",
-                  "code": "363589002"
-                }
-              ],
               "text": "Behandeling",
               "required": false,
               "repeats": false,
@@ -1791,27 +1504,7 @@
                   "text": "Toelichting",
                   "type": "string",
                   "required": false,
-                  "repeats": false,
-                  "code": [
-                    {
-                      "code": "48767-8"
-                    }
-                  ]
-                }
-              ],
-              "code": [
-                {
-                  "code": "0"
-                },
-                {
-                  "code": "1"
-                },
-                {
-                  "code": "2"
-                },
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
-                  "code": "UNK"
+                  "repeats": false
                 }
               ]
             }
@@ -1827,12 +1520,6 @@
             {
               "type": "choice",
               "linkId": "1418",
-              "code": [
-                {
-                  "system": "http://snomed.info/sct",
-                  "code": "363589002"
-                }
-              ],
               "text": "Behandeling",
               "required": false,
               "repeats": false,
@@ -1908,27 +1595,7 @@
                   "text": "Toelichting",
                   "type": "string",
                   "required": false,
-                  "repeats": false,
-                  "code": [
-                    {
-                      "code": "48767-8"
-                    }
-                  ]
-                }
-              ],
-              "code": [
-                {
-                  "code": "0"
-                },
-                {
-                  "code": "1"
-                },
-                {
-                  "code": "2"
-                },
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
-                  "code": "UNK"
+                  "repeats": false
                 }
               ]
             }
@@ -1958,12 +1625,6 @@
                 }
               ],
               "linkId": "1420",
-              "code": [
-                {
-                  "system": "http://snomed.info/sct",
-                  "code": "363589002"
-                }
-              ],
               "text": "Behandeling",
               "required": false,
               "repeats": false,
@@ -2039,27 +1700,7 @@
                   "text": "Toelichting",
                   "type": "string",
                   "required": false,
-                  "repeats": false,
-                  "code": [
-                    {
-                      "code": "48767-8"
-                    }
-                  ]
-                }
-              ],
-              "code": [
-                {
-                  "code": "0"
-                },
-                {
-                  "code": "1"
-                },
-                {
-                  "code": "2"
-                },
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
-                  "code": "UNK"
+                  "repeats": false
                 }
               ]
             }
@@ -2070,12 +1711,6 @@
             {
               "type": "open-choice",
               "linkId": "1422",
-              "code": [
-                {
-                  "system": "http://snomed.info/sct",
-                  "code": "363589002"
-                }
-              ],
               "text": "Behandeling",
               "required": false,
               "repeats": false,
@@ -2096,11 +1731,6 @@
                 {
                   "type": "string",
                   "linkId": "1404",
-                  "code": [
-                    {
-                      "code": "48767-8"
-                    }
-                  ],
                   "text": "Toelichting",
                   "required": false,
                   "repeats": false
@@ -2108,21 +1738,6 @@
               ],
               "type": "choice",
               "linkId": "1402",
-              "code": [
-                {
-                  "code": "0"
-                },
-                {
-                  "code": "1"
-                },
-                {
-                  "code": "2"
-                },
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
-                  "code": "UNK"
-                }
-              ],
               "text": "BehandelBesluit",
               "required": false,
               "repeats": false,
@@ -2239,12 +1854,6 @@
             {
               "type": "choice",
               "linkId": "1426",
-              "code": [
-                {
-                  "system": "http://snomed.info/sct",
-                  "code": "363589002"
-                }
-              ],
               "text": "Behandeling van uitzetten ICD (Behandeling)",
               "required": false,
               "repeats": false,
@@ -2265,11 +1874,6 @@
                 {
                   "type": "string",
                   "linkId": "1010",
-                  "code": [
-                    {
-                      "code": "48767-8"
-                    }
-                  ],
                   "text": "Toelichting gemaakte afspraken",
                   "required": false,
                   "repeats": false
@@ -2277,20 +1881,6 @@
               ],
               "type": "choice",
               "linkId": "1005",
-              "code": [
-                {
-                  "system": "urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.25.1",
-                  "code": "0"
-                },
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
-                  "code": "ASKU"
-                },
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
-                  "code": "NASK"
-                }
-              ],
               "text": "Afspraak uitzetten ICD (BehandelBesluit)",
               "enableWhen": [
                 {
@@ -2384,12 +1974,6 @@
             {
               "type": "string",
               "linkId": "1190",
-              "code": [
-                {
-                  "system": "http://snomed.info/sct",
-                  "code": "441742003"
-                }
-              ],
               "text": "Wens en verwachting patient ([MetingWaarde])",
               "required": false,
               "repeats": false
@@ -2428,22 +2012,11 @@
                   "text": "Toelichting",
                   "type": "string",
                   "required": false,
-                  "repeats": false,
-                  "code": [
-                    {
-                      "code": "48767-8"
-                    }
-                  ]
+                  "repeats": false
                 }
               ],
               "type": "choice",
               "linkId": "1191",
-              "code": [
-                {
-                  "system": "http://snomed.info/sct",
-                  "code": "441742003"
-                }
-              ],
               "text": "Voorkeursplek ([MetingWaarde])",
               "required": false,
               "repeats": false,
@@ -2526,22 +2099,11 @@
                   "text": "Toelichting",
                   "type": "string",
                   "required": false,
-                  "repeats": false,
-                  "code": [
-                    {
-                      "code": "48767-8"
-                    }
-                  ]
+                  "repeats": false
                 }
               ],
               "type": "choice",
               "linkId": "1193",
-              "code": [
-                {
-                  "system": "http://snomed.info/sct",
-                  "code": "441742003"
-                }
-              ],
               "text": "Euthanasie standpunt ([MetingWaarde])",
               "required": false,
               "repeats": false,
@@ -2631,12 +2193,6 @@
                     "display": "Nog onbekend"
                   }
                 }
-              ],
-              "code": [
-                {
-                  "system": "http://snomed.info/sct",
-                  "code": "441742003"
-                }
               ]
             }
           ]
@@ -2687,13 +2243,7 @@
           "text": "Wat verder nog belangrijk is ([MetingWaarde])",
           "type": "string",
           "required": false,
-          "repeats": false,
-          "code": [
-            {
-              "system": "http://snomed.info/sct",
-              "code": "441742003"
-            }
-          ]
+          "repeats": false
         }
       ]
     },
@@ -2814,12 +2364,6 @@
                 "code": "0",
                 "display": "Nee"
               }
-            }
-          ],
-          "code": [
-            {
-              "system": "http://snomed.info/sct",
-              "code": "223449006"
             }
           ]
         },

--- a/util/questionnaire_item_code_remover.py
+++ b/util/questionnaire_item_code_remover.py
@@ -1,0 +1,64 @@
+"""
+Remove all 'code' elements from Questionnaire items at every nesting level.
+
+Usage:
+    python util/remove_item_codes.py [--dry-run]
+
+This script processes Questionnaire-ACP-zib2020.json and removes
+the 'code' property from every item (recursively through all nested items).
+"""
+
+import json
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+QUESTIONNAIRE_PATH = SCRIPT_DIR.parent / "input" / "resources" / "Questionnaire-ACP-zib2020.json"
+
+
+def remove_codes_from_items(items: list, path: str = "item") -> int:
+    """Recursively remove 'code' from all items. Returns count of removed elements."""
+    count = 0
+    for i, item in enumerate(items):
+        item_path = f"{path}[{i}] (linkId={item.get('linkId', '?')})"
+        if "code" in item:
+            print(f"  Removing 'code' from {item_path}")
+            del item["code"]
+            count += 1
+        if "item" in item:
+            count += remove_codes_from_items(item["item"], path=f"{item_path}.item")
+    return count
+
+
+def main():
+    dry_run = "--dry-run" in sys.argv
+
+    if not QUESTIONNAIRE_PATH.exists():
+        print(f"ERROR: File not found: {QUESTIONNAIRE_PATH}")
+        sys.exit(1)
+
+    print(f"Processing: {QUESTIONNAIRE_PATH}")
+    if dry_run:
+        print("(dry-run mode — no changes will be written)\n")
+
+    with open(QUESTIONNAIRE_PATH, "r", encoding="utf-8") as f:
+        questionnaire = json.load(f)
+
+    items = questionnaire.get("item", [])
+    removed = remove_codes_from_items(items)
+
+    print(f"\nTotal 'code' elements removed: {removed}")
+
+    if not dry_run and removed > 0:
+        with open(QUESTIONNAIRE_PATH, "w", encoding="utf-8") as f:
+            json.dump(questionnaire, f, indent=2, ensure_ascii=False)
+            f.write("\n")
+        print("File saved.")
+    elif dry_run:
+        print("No changes written (dry-run).")
+    else:
+        print("No changes needed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Remove numerous incorrect 'code' properties from input/resources/Questionnaire-ACP-zib2020.json at multiple nesting levels, cleaning up terminology/code elements in questionnaire items. Add util/questionnaire_item_code_remover.py — a small Python utility that recursively removes 'code' keys from all questionnaire items, supports a --dry-run mode, and writes back a formatted JSON file when changes are made.