### PR TITLE
Add subject to QuestionnaireResponse resources

### DIFF
--- a/input/resources/QuestionnaireResponse-HendrikHartman-20201001.json
+++ b/input/resources/QuestionnaireResponse-HendrikHartman-20201001.json
@@ -11,6 +11,10 @@
   "status": "completed",
   "authored": "2025-08-25T19:14:50.150Z",
   "questionnaire": "https://api.iknl.nl/docs/pzp/r4/Questionnaire/ACP-zib2020|1.0.0-rc2",
+  "subject": {
+    "reference": "Patient/ACP-Patient-HendrikHartman-Pat1",
+    "display": "Patient, Hendrik Hartman"
+  },
   "author": 
     {
       "reference": "PractitionerRole/ACP-HealthProfessional-PractitionerRole-DrVanHuissen-Pat1",

--- a/input/resources/QuestionnaireResponse-HendrikHartman-20221108.json
+++ b/input/resources/QuestionnaireResponse-HendrikHartman-20221108.json
@@ -11,6 +11,10 @@
   "status": "completed",
   "authored": "2025-08-25T19:18:32.253Z",
   "questionnaire": "https://api.iknl.nl/docs/pzp/r4/Questionnaire/ACP-zib2020|1.0.0-rc2",
+  "subject": {
+    "reference": "Patient/ACP-Patient-HendrikHartman-Pat1",
+    "display": "Patient, Hendrik Hartman"
+  },
   "author": 
     {
       "reference": "PractitionerRole/ACP-HealthProfessional-PractitionerRole-DrVanHuissen-Pat1",

--- a/input/resources/QuestionnaireResponse-SamiraVanDerSluijs-20251117.json
+++ b/input/resources/QuestionnaireResponse-SamiraVanDerSluijs-20251117.json
@@ -11,14 +11,16 @@
   "status": "completed",
   "authored": "2025-11-27T16:15:00.733Z",
   "questionnaire": "https://api.iknl.nl/docs/pzp/r4/Questionnaire/ACP-zib2020|1.0.0-rc2",
-    "author": 
-    {
-      "reference": "PractitionerRole/ACP-HealthProfessional-PractitionerRole-DesireeWolters-Pat2",
-      "display": "Healthcare professional (role), Desiree Wolters"
-    }
-  ,
+  "subject": {
+    "reference": "Patient/ACP-Patient-SamiraVanDerSluijs-Pat2",
+    "display": "Patient, Samira van der Sluijs"
+  },
+  "author": {
+    "reference": "PractitionerRole/ACP-HealthProfessional-PractitionerRole-DesireeWolters-Pat2",
+    "display": "Healthcare professional (role), Desiree Wolters"
+  },
   "source": {
-    "reference": "Patient/ACP-Patient-SamiraVanDerSluijs-Pat2", 
+    "reference": "Patient/ACP-Patient-SamiraVanDerSluijs-Pat2",
     "display": "Patient, Samira van der Sluijs"
   },
   "item": [


### PR DESCRIPTION
Add a 'subject' object (patient reference and display) to three QuestionnaireResponse JSON files: HendrikHartman (20201001 and 20221108) and SamiraVanDerSluijs (20251117). Also normalize the author block placement/formatting in the Samira file and ensure the source reference/display remains consistent; minor formatting fixes (whitespace/newline) applied.