### PR TITLE
#129 Add roleAdditional slice to ACP ContactPerson intro

### DIFF
--- a/input/pagecontent/StructureDefinition-ACP-ContactPerson-intro.md
+++ b/input/pagecontent/StructureDefinition-ACP-ContactPerson-intro.md
@@ -2,4 +2,4 @@
 
 This profile adds ACP-specific mappings to the ART-DECOR dataset and obligation extensions for Provider and Consulter actors. Profile references are constrained to ACP profiles where available. The following change affects implementation beyond the base nl-core profile:
 
-* An additional slice `.relationship:roleAdditional` has been added, bound to [ACPContactPersonRoleVS](ValueSet-ACPContactPersonRoleVS.html). This slice accommodates role codes required by the ACP dataset that are not included in the `RolCodelijst` bound to `.relationship:role` (e.g. SNOMED CT code `310141000146103` _Schriftelijk gemachtigde zorg en behandeling_).
+* An additional slice `.relationship:roleAdditional` has been added, bound to [ACPContactPersonRoleVS](ValueSet-ACPContactPersonRoleVS.html). This slice accommodates role codes required by the ACP dataset that are not included in the `RolCodelijst` bound to `.relationship:role` (e.g. SNOMED CT code `310141000146103` _Schriftelijk gemachtigde zorg en behandeling_, pre-adopted from the [RolCodelijst in zib Contactpersoon v4.1 (2024)](https://zibs.nl/wiki/Contactpersoon-v4.1(2024NL)#RolCodelijst)).

--- a/input/pagecontent/StructureDefinition-ACP-ContactPerson-intro.md
+++ b/input/pagecontent/StructureDefinition-ACP-ContactPerson-intro.md
@@ -2,4 +2,4 @@
 
 This profile adds ACP-specific mappings to the ART-DECOR dataset and obligation extensions for Provider and Consulter actors. Profile references are constrained to ACP profiles where available. The following change affects implementation beyond the base nl-core profile:
 
-* `.relationship:role` is mandatory.
+* An additional slice `.relationship:roleAdditional` has been added, bound to [ACPContactPersonRoleVS](ValueSet-ACPContactPersonRoleVS.html). This slice accommodates role codes required by the ACP dataset that are not included in the `RolCodelijst` bound to `.relationship:role` (e.g. SNOMED CT code `310141000146103` _Schriftelijk gemachtigde zorg en behandeling_).


### PR DESCRIPTION
Update the StructureDefinition-ACP-ContactPerson intro: replace the prior note that `.relationship:role` is mandatory with documentation of a new slice `.relationship:roleAdditional`. The new slice is bound to ACPContactPersonRoleVS to accommodate ACP dataset role codes not present in the RolCodelijst (for example SNOMED CT code 310141000146103).