### PR TITLE
#134 Switch to CommunicationRequest; update SNOMED code

### DIFF
--- a/input/fsh/CapabilityStatement.fsh
+++ b/input/fsh/CapabilityStatement.fsh
@@ -567,7 +567,7 @@ Usage: #definition
     * extension
       * url = $CapExpectation
       * valueCode = #SHALL
-    * type = #Communication
+    * type = #CommunicationRequest
     * supportedProfile[0] = "https://api.iknl.nl/docs/pzp/r4/StructureDefinition/ACP-InformRelativesRequest"
       * extension
         * url = $CapExpectation

--- a/input/includes/fhir-data-exchange-individual-resources-mermaid-diagram.md
+++ b/input/includes/fhir-data-exchange-individual-resources-mermaid-diagram.md
@@ -47,7 +47,7 @@ sequenceDiagram
             deactivate S
         and
             %% 7. CommunicationRequests
-            C->>S: GET /CommunicationRequest?patient=Patient/[id]<br>&category=http://snomed.info/sct|713603004
+            C->>S: GET /CommunicationRequest?patient=Patient/[id]<br>&category=http://snomed.info/sct|223449006
             activate S
             S-->>C: 200 OK: Bundle (CommunicationRequest)
             deactivate S


### PR DESCRIPTION
Update CapabilityStatement FSH to use type CommunicationRequest (was Communication) for the ACP-InformRelativesRequest profile. Also update the example mermaid sequence diagram to use SNOMED code 223449006 for the CommunicationRequest category, ensuring the diagram and capability statement align with the correct resource type and category code.