### PR TITLE
Replace Patient legallycapable extension with an Observation

### DIFF
--- a/input/fsh/CapabilityStatement.fsh
+++ b/input/fsh/CapabilityStatement.fsh
@@ -139,7 +139,11 @@ Usage: #definition
       * valueCode = #SHOULD
     * type = #Observation
     // Supported profiles for Observation resource are set to SHOULD because not all Observation have to be implemented.
-    * supportedProfile[0] = "https://api.iknl.nl/docs/pzp/r4/StructureDefinition/ACP-OrganDonationChoiceRegistration"
+    * supportedProfile[0] = "https://api.iknl.nl/docs/pzp/r4/StructureDefinition/ACP-LegallyCapable"
+      * extension
+        * url = $CapExpectation
+        * valueCode = #SHOULD
+    * supportedProfile[+] = "https://api.iknl.nl/docs/pzp/r4/StructureDefinition/ACP-OrganDonationChoiceRegistration"
       * extension
         * url = $CapExpectation
         * valueCode = #SHOULD 
@@ -483,7 +487,11 @@ Usage: #definition
       * valueCode = #SHALL
     * type = #Observation
     // Supported profiles for Observation resource are set to SHOULD because not all Observation have to be implemented.
-    * supportedProfile[0] = "https://api.iknl.nl/docs/pzp/r4/StructureDefinition/ACP-OrganDonationChoiceRegistration"
+    * supportedProfile[0] = "https://api.iknl.nl/docs/pzp/r4/StructureDefinition/ACP-LegallyCapable"
+      * extension
+        * url = $CapExpectation
+        * valueCode = #SHOULD 
+    * supportedProfile[+] = "https://api.iknl.nl/docs/pzp/r4/StructureDefinition/ACP-OrganDonationChoiceRegistration"
       * extension
         * url = $CapExpectation
         * valueCode = #SHOULD 

--- a/input/fsh/Observation.fsh
+++ b/input/fsh/Observation.fsh
@@ -354,7 +354,7 @@ Profile: ACPLegallyCapable
 Parent: Observation
 Id: ACP-LegallyCapable
 Title: "ACP Legally Capable"
-Description: "Indicator of capability of patient to make informed decisions about their healthcare. Based on Observation resource."
+Description: "Indicates whether the patient is currently assessed as having the capacity to understand and oversee the consequences of medical treatment decisions. Based on Observation resource."
 * insert MetaRules
 * encounter only Reference(ACPEncounter)
 * subject only Reference(ACPPatient)
@@ -376,10 +376,8 @@ Title: "ACP dataset"
 Source: ACPLegallyCapable
 Target: "https://decor.nictiz.nl/exist/apps/api/dataset/2.16.840.1.113883.2.4.3.11.60.117.1.1/2020-07-29T10%3A37%3A48/$view?language=nl-NL&ui=nl-NL&format=html&hidecolumns=3456gh&release=2026-02-24T09:29:59"
 * -> "761" "Wilsbekwaamheid m.b.t. medische behandelbeslissingen"
-// * code -> "667" "Gewenste plek van overlijden ([Meting])"
 * valueBoolean -> "762" "Wilsbekwaamheid m.b.t. medische behandelbeslissingen"
-* dataAbsentReason -> "668" "Wilsbekwaamheid m.b.t. medische behandelbeslissingen"
-//* effective[x] -> "672" "[MeetDatumBeginTijd]"
+* dataAbsentReason -> "762" "Wilsbekwaamheid m.b.t. medische behandelbeslissingen"
 * note.text -> "763" "[Toelichting]"
 
 

--- a/input/fsh/Observation.fsh
+++ b/input/fsh/Observation.fsh
@@ -358,7 +358,7 @@ Description: "Indicator of capability of patient to make informed decisions abou
 * insert MetaRules
 * encounter only Reference(ACPEncounter)
 * subject only Reference(ACPPatient)
-* code = $snomed#665631000146103
+* code = $snomed#665671000146101
 * value[x] only boolean
 
 * insert ObligationRules(encounter)
@@ -394,7 +394,7 @@ Usage: #example
 * subject = Reference(ACP-Patient-HendrikHartman-Pat1) "Patient, Hendrik Hartman"
 * performer = Reference(ACP-HealthProfessional-PractitionerRole-DrVanHuissen-Pat1) "Healthcare professional (role), van Huissen"
 * status = #final
-* code =  $snomed#665631000146103 "juridisch vermogen om beslissingen te nemen over medische behandelingen"
+* code =  $snomed#665671000146101 "juridisch in staat om beslissingen te nemen over medische behandelingen"
 * valueBoolean = true
 * effectiveDateTime = "2020-10-01"
 
@@ -410,7 +410,7 @@ Usage: #example
 * subject = Reference(ACP-Patient-SamiraVanDerSluijs-Pat2) "Patient, Samira van der Sluijs"
 * performer = Reference(ACP-HealthProfessional-PractitionerRole-DesireeWolters-Pat2) "Healthcare professional (role), Desiree Wolters"
 * status = #final
-* code =  $snomed#665631000146103 "juridisch vermogen om beslissingen te nemen over medische behandelingen"
+* code =  $snomed#665671000146101 "juridisch in staat om beslissingen te nemen over medische behandelingen"
 * valueBoolean = true
 * effectiveDateTime = "2025-08-07"
 * note.text = "Patiënt is wilsbekwaam. Bij verandering van de situatie wordt haar partner haar wettelijk vertegenwoordiger."

--- a/input/fsh/Observation.fsh
+++ b/input/fsh/Observation.fsh
@@ -348,3 +348,69 @@ Usage: #example
 * code =  $snomed#247751003 "gevoel van zingeving"
 * valueString = "Mevrouw is gek op haar kleinzoon, dus brengt graag veel tijd met hem door."
 * effectiveDateTime = "2025-08-07"
+
+
+Profile: ACPLegallyCapable
+Parent: Observation
+Id: ACP-LegallyCapable
+Title: "ACP Legally Capable"
+Description: "Indicator of capability of patient to make informed decisions about their healthcare. Based on Observation resource."
+* insert MetaRules
+* encounter only Reference(ACPEncounter)
+* subject only Reference(ACPPatient)
+* code = $snomed#304686002
+* value[x] only Boolean
+
+* insert ObligationRules(encounter)
+* insert ObligationRules(subject)
+* insert ObligationRules(code)
+* insert ObligationRules(valueBoolean)
+* insert ObligationRules(dataAbsentReason)
+* insert ObligationRules(effective[x])
+* insert ObligationRules(note.text)
+* insert ObligationRules(performer)
+
+Mapping: MapACPLegallyCapable
+Id: pall-izppz-zib2020v2026-02-24
+Title: "ACP dataset"
+Source: ACPLegallyCapable
+Target: "https://decor.nictiz.nl/exist/apps/api/dataset/2.16.840.1.113883.2.4.3.11.60.117.1.1/2020-07-29T10%3A37%3A48/$view?language=nl-NL&ui=nl-NL&format=html&hidecolumns=3456gh&release=2026-02-24T09:29:59"
+* -> "761" "Wilsbekwaamheid m.b.t. medische behandelbeslissingen"
+// * code -> "667" "Gewenste plek van overlijden ([Meting])"
+* valueBoolean -> "762" "Wilsbekwaamheid m.b.t. medische behandelbeslissingen"
+* dataAbsentReason -> "668" "Wilsbekwaamheid m.b.t. medische behandelbeslissingen"
+//* effective[x] -> "672" "[MeetDatumBeginTijd]"
+* note.text -> "763" "[Toelichting]"
+
+
+Instance: ACP-LegallyCapable-Pat1
+InstanceOf: ACPLegallyCapable
+Title: "ACP Legally Capable - Pat 1"
+Usage: #example
+* identifier.type = $v2-0203#RI "Resource identifier"
+* identifier.system = "https://acme.com/fhir/NamingSystem/resource-business-identifier"
+* identifier.value = "928e493b-3265-46ad-a155-b46d3d31b821"
+* encounter = Reference(ACP-Encounter-Pat1) "Encounter, 2020-10-01"
+* subject = Reference(ACP-Patient-HendrikHartman-Pat1) "Patient, Hendrik Hartman"
+* performer = Reference(ACP-HealthProfessional-PractitionerRole-DrVanHuissen-Pat1) "Healthcare professional (role), van Huissen"
+* status = #final
+* code =  $snomed#304686002 "Ability to make considered choices"
+* valueBoolean = true
+* effectiveDateTime = "2020-10-01"
+
+
+Instance: ACP-LegallyCapable-Pat2
+InstanceOf: ACPLegallyCapable
+Title: "ACP Legally Capable - Pat 2"
+Usage: #example
+* identifier.type = $v2-0203#RI "Resource identifier"
+* identifier.system = "https://acme.com/fhir/NamingSystem/resource-business-identifier"
+* identifier.value = "337d9e4a-08a3-486f-9f24-d6c60c6f342a"
+* encounter = Reference(ACP-Encounter-1-Pat2) "Encounter, 2025-08-07"
+* subject = Reference(ACP-Patient-SamiraVanDerSluijs-Pat2) "Patient, Samira van der Sluijs"
+* performer = Reference(ACP-HealthProfessional-PractitionerRole-DesireeWolters-Pat2) "Healthcare professional (role), Desiree Wolters"
+* status = #final
+* code =  $snomed#304686002 "Ability to make considered choices"
+* valueBoolean = true
+* effectiveDateTime = "2025-08-07"
+* note.text = "Patiënt is wilsbekwaam. Bij verandering van de situatie wordt haar partner haar wettelijk vertegenwoordiger."

--- a/input/fsh/Observation.fsh
+++ b/input/fsh/Observation.fsh
@@ -359,7 +359,7 @@ Description: "Indicator of capability of patient to make informed decisions abou
 * encounter only Reference(ACPEncounter)
 * subject only Reference(ACPPatient)
 * code = $snomed#304686002
-* value[x] only Boolean
+* value[x] only boolean
 
 * insert ObligationRules(encounter)
 * insert ObligationRules(subject)

--- a/input/fsh/Observation.fsh
+++ b/input/fsh/Observation.fsh
@@ -354,7 +354,7 @@ Profile: ACPLegallyCapable
 Parent: Observation
 Id: ACP-LegallyCapable
 Title: "ACP Legally Capable"
-Description: "Indicates whether the patient is currently assessed as having the capacity to understand and oversee the consequences of medical treatment decisions. Based on Observation resource."
+Description: "Indicates whether the patient is currently assessed as having the capacity to understand and oversee the consequences of medical treatment decisions. If the patient is not legally capable, there should be a legal representative captured in a RelatedPerson resource. Based on Observation resource."
 * insert MetaRules
 * encounter only Reference(ACPEncounter)
 * subject only Reference(ACPPatient)

--- a/input/fsh/Observation.fsh
+++ b/input/fsh/Observation.fsh
@@ -358,7 +358,7 @@ Description: "Indicator of capability of patient to make informed decisions abou
 * insert MetaRules
 * encounter only Reference(ACPEncounter)
 * subject only Reference(ACPPatient)
-* code = $snomed#304686002
+* code = $snomed#665631000146103
 * value[x] only boolean
 
 * insert ObligationRules(encounter)
@@ -394,7 +394,7 @@ Usage: #example
 * subject = Reference(ACP-Patient-HendrikHartman-Pat1) "Patient, Hendrik Hartman"
 * performer = Reference(ACP-HealthProfessional-PractitionerRole-DrVanHuissen-Pat1) "Healthcare professional (role), van Huissen"
 * status = #final
-* code =  $snomed#304686002 "Ability to make considered choices"
+* code =  $snomed#665631000146103 "juridisch vermogen om beslissingen te nemen over medische behandelingen"
 * valueBoolean = true
 * effectiveDateTime = "2020-10-01"
 
@@ -410,7 +410,7 @@ Usage: #example
 * subject = Reference(ACP-Patient-SamiraVanDerSluijs-Pat2) "Patient, Samira van der Sluijs"
 * performer = Reference(ACP-HealthProfessional-PractitionerRole-DesireeWolters-Pat2) "Healthcare professional (role), Desiree Wolters"
 * status = #final
-* code =  $snomed#304686002 "Ability to make considered choices"
+* code =  $snomed#665631000146103 "juridisch vermogen om beslissingen te nemen over medische behandelingen"
 * valueBoolean = true
 * effectiveDateTime = "2025-08-07"
 * note.text = "Patiënt is wilsbekwaam. Bij verandering van de situatie wordt haar partner haar wettelijk vertegenwoordiger."

--- a/input/fsh/Patient.fsh
+++ b/input/fsh/Patient.fsh
@@ -4,18 +4,11 @@ Id: ACP-Patient
 Title: "ACP Patient"
 Description: "A person who receives medical, psychological, paramedical, or nursing care. Based on nl-core-Patient and HCIM Patient."
 * insert MetaRules
-* obeys ACP-Patient-1
-* extension contains
-    ExtPatientLegallyCapableMedicalTreatmentDecisions  named legallyCapableMedicalTreatmentDecisions 0..1
-* extension[legallyCapableMedicalTreatmentDecisions] ^condition = "ACP-Patient-1"
 * name 1..*
-* contact ^condition = "ACP-Patient-1"
-* contact.extension[relatedPerson] ^condition = "ACP-Patient-1"
 * contact.extension[relatedPerson] ^comment = "All information regarding the patient's contact persons should preferably be stored in the RelatedPerson resource, and optionally in `Patient.contact`. The http://hl7.org/fhir/StructureDefinition/patient-relatedPerson extension is used to link the contact person to the Patient and to emphasize that the related person is also a contact person of the patient."
 * contact.extension[relatedPerson].valueReference only Reference(ACPContactPerson)
-* contact.relationship ^condition = "ACP-Patient-1"
 
-* insert ObligationRules(extension[legallyCapableMedicalTreatmentDecisions])
+
 * insert ObligationRules(contact.extension[relatedPerson])
 * insert ObligationRules(identifier)
 * insert ObligationRules(name[nameInformation].given)
@@ -48,13 +41,6 @@ Description: "A person who receives medical, psychological, paramedical, or nurs
 * insert ObligationRules(address.use)
 * insert ObligationRules(address.type)
 
-
-Invariant: ACP-Patient-1
-Description: "If the patient is not legally capable, there should be a legal representative."
-* severity = #warning
-* expression = "extension.where(url='https://api.iknl.nl/docs/pzp/r4/StructureDefinition/ext-LegallyCapable-MedicalTreatmentDecisions').extension.where(url='legallyCapable').value = false implies (contact.where(relationship.coding.code = '24').exists() or contact.extension.where(url='http://hl7.org/fhir/StructureDefinition/patient-relatedPerson').exists())"
-
-
 Mapping: MapACPPatient
 Id: pall-izppz-zib2020v2026-02-24
 Title: "ACP dataset"
@@ -63,9 +49,6 @@ Target: "https://decor.nictiz.nl/exist/apps/api/dataset/2.16.840.1.113883.2.4.3.
 * -> "351" "Patient"
 * -> "613" "Patient"
 * -> "648" "Patient"
-* extension[legallyCapableMedicalTreatmentDecisions] -> "761" "Wilsbekwaamheid m.b.t. medische behandelbeslissingen" 
-* extension[legallyCapableMedicalTreatmentDecisions].extension[legallyCapable] -> "762" "Wilsbekwaamheid m.b.t. medische behandelbeslissingen"
-* extension[legallyCapableMedicalTreatmentDecisions].extension[legallyCapableComment] -> "763" "Toelichting"
 * identifier -> "385" "Identificatienummer"
 * name -> "352" "Naamgegevens"
 * name[nameInformation].given -> "353" "Voornamen"
@@ -123,7 +106,6 @@ Instance: ACP-Patient-HendrikHartman-Pat1
 InstanceOf: ACPPatient
 Title: "ACP Patient - Hendrik Hartman - Pat 1"
 Usage: #example
-* extension[legallyCapableMedicalTreatmentDecisions].extension[legallyCapable].valueBoolean = true
 * identifier.system = "http://fhir.nl/fhir/NamingSystem/bsn"
 * identifier.value = "999911120"
 * name[nameInformation].extension.url = "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order"
@@ -162,8 +144,6 @@ Instance: ACP-Patient-SamiraVanDerSluijs-Pat2
 InstanceOf: ACPPatient
 Title: "ACP Patient - Samira van der Sluijs - Pat 2"
 Usage: #example
-* extension[legallyCapableMedicalTreatmentDecisions].extension[legallyCapable].valueBoolean = true
-* extension[legallyCapableMedicalTreatmentDecisions].extension[legallyCapableComment].valueString = "Patiënt is wilsbekwaam. Bij verandering van de situatie wordt haar partner haar wettelijk vertegenwoordiger."
 * identifier.system = "http://fhir.nl/fhir/NamingSystem/bsn"
 * identifier.value = "999998298"
 * name[0].use = #official

--- a/input/includes/fhir-data-exchange-individual-resources-mermaid-diagram.md
+++ b/input/includes/fhir-data-exchange-individual-resources-mermaid-diagram.md
@@ -35,7 +35,7 @@ sequenceDiagram
             deactivate S
         and
             %% 5. Observations
-            C->>S: GET /Observation?patient=Patient/[id]<br>&code=http://snomed.info/sct|153851000146100,395091006,340171000146104,247751003
+            C->>S: GET /Observation?patient=Patient/[id]<br>&code=http://snomed.info/sct|665671000146101,153851000146100,395091006,340171000146104,247751003,570801000146104
             activate S
             S-->>C: 200 OK: Bundle (Observation)
             deactivate S

--- a/input/includes/fhir-data-model-mermaid-diagram.md
+++ b/input/includes/fhir-data-model-mermaid-diagram.md
@@ -56,6 +56,7 @@ flowchart TB
     end
 
     subgraph "Observation"
+        ACPLegallyCapable
         ACPOrganDonationChoiceRegistration
         ACPPositionRegardingEuthanasia
         ACPPreferredPlaceOfDeath
@@ -76,6 +77,7 @@ flowchart TB
     class ACPPositionRegardingEuthanasia C0
     class ACPOrganDonationChoiceRegistration C0
     class ACPSenseOfPurpose C0
+    class ACPLegallyCapable C0
     class ACPPatient C1
     class ACPHealthProfessionalPractitioner C1
     class ACPHealthProfessionalPractitionerRole C1

--- a/input/includes/mappings.md
+++ b/input/includes/mappings.md
@@ -62,9 +62,10 @@ This table provides an overview of all dataset elements that are mapped to FHIR 
 | 399 | &emsp;&emsp;&emsp;Voorvoegsels | Practitioner (<a href="StructureDefinition-ACP-HealthProfessional-Practitioner.html">ACPHealthProfessionalPractitioner</a>) | `name[nameInformation].family.extension[prefix]`  |
 | 400 | &emsp;&emsp;&emsp;Achternaam | Practitioner (<a href="StructureDefinition-ACP-HealthProfessional-Practitioner.html">ACPHealthProfessionalPractitioner</a>) | `name[nameInformation].family.extension[lastName]`  |
 | 405 | &emsp;Functie (Specialisme) | PractitionerRole (<a href="StructureDefinition-ACP-HealthProfessional-PractitionerRole.html">ACPHealthProfessionalPractitionerRole</a>) | `specialty[specialty]`  |
-| 761 | Wilsbekwaamheid m.b.t. medische behandelbeslissingen | Patient (<a href="StructureDefinition-ACP-Patient.html">ACPPatient</a>) | `extension[legallyCapableMedicalTreatmentDecisions]`  |
-| 762 | &emsp;Wilsbekwaamheid m.b.t. medische behandelbeslissingen | Patient (<a href="StructureDefinition-ACP-Patient.html">ACPPatient</a>) | `extension[legallyCapableMedicalTreatmentDecisions].extension[legallyCapable]`  |
-| 763 | &emsp;Toelichting | Patient (<a href="StructureDefinition-ACP-Patient.html">ACPPatient</a>) | `extension[legallyCapableMedicalTreatmentDecisions].extension[legallyCapableComment]`  |
+| 761 | Wilsbekwaamheid m.b.t. medische behandelbeslissingen | Observation (<a href="StructureDefinition-ACP-LegallyCapable.html">ACPLegallyCapable</a>) | ``  |
+| 762 | &emsp;Wilsbekwaamheid m.b.t. medische behandelbeslissingen | Observation (<a href="StructureDefinition-ACP-LegallyCapable.html">ACPLegallyCapable</a>) | `valueBoolean`  |
+| 762 | &emsp;Wilsbekwaamheid m.b.t. medische behandelbeslissingen | Observation (<a href="StructureDefinition-ACP-LegallyCapable.html">ACPLegallyCapable</a>) | `dataAbsentReason`  |
+| 763 | &emsp;Toelichting | Observation (<a href="StructureDefinition-ACP-LegallyCapable.html">ACPLegallyCapable</a>) | `note.text`  |
 | 441 | Wettelijk vertegenwoordiger (Contactpersoon) | RelatedPerson (<a href="StructureDefinition-ACP-ContactPerson.html">ACPContactPerson</a>) | ``  |
 | 442 | &emsp;Naamgegevens | RelatedPerson (<a href="StructureDefinition-ACP-ContactPerson.html">ACPContactPerson</a>) | `name`  |
 | 443 | &emsp;&emsp;Voornamen | RelatedPerson (<a href="StructureDefinition-ACP-ContactPerson.html">ACPContactPerson</a>) | `name[nameInformation].given`  |

--- a/input/pagecontent/data-exchange.md
+++ b/input/pagecontent/data-exchange.md
@@ -46,7 +46,7 @@ The below listed search requests show how all the ACP agreements, procedural inf
 
 4 GET [base]/Goal?patient=Patient/[id]&category=http://snomed.info/sct|713603004
 
-5 GET [base]/Observation?patient=Patient/[id]&code=http://snomed.info/sct|304686002,153851000146100,395091006,340171000146104,247751003,570801000146104
+5 GET [base]/Observation?patient=Patient/[id]&code=http://snomed.info/sct|665631000146103,153851000146100,395091006,340171000146104,247751003,570801000146104
 
 6 GET [base]/DeviceUseStatement?patient=Patient/[id]&device.type=http://snomed.info/sct|72506001,465460004,468542000,704707009,1263462004,1236894001&_include=DeviceUseStatement:device
 

--- a/input/pagecontent/data-exchange.md
+++ b/input/pagecontent/data-exchange.md
@@ -46,7 +46,7 @@ The below listed search requests show how all the ACP agreements, procedural inf
 
 4 GET [base]/Goal?patient=Patient/[id]&category=http://snomed.info/sct|713603004
 
-5 GET [base]/Observation?patient=Patient/[id]&code=http://snomed.info/sct|665631000146103,153851000146100,395091006,340171000146104,247751003,570801000146104
+5 GET [base]/Observation?patient=Patient/[id]&code=http://snomed.info/sct|665671000146101,153851000146100,395091006,340171000146104,247751003,570801000146104
 
 6 GET [base]/DeviceUseStatement?patient=Patient/[id]&device.type=http://snomed.info/sct|72506001,465460004,468542000,704707009,1263462004,1236894001&_include=DeviceUseStatement:device
 

--- a/input/pagecontent/data-exchange.md
+++ b/input/pagecontent/data-exchange.md
@@ -46,7 +46,7 @@ The below listed search requests show how all the ACP agreements, procedural inf
 
 4 GET [base]/Goal?patient=Patient/[id]&category=http://snomed.info/sct|713603004
 
-5 GET [base]/Observation?patient=Patient/[id]&code=http://snomed.info/sct|153851000146100,395091006,340171000146104,247751003,570801000146104
+5 GET [base]/Observation?patient=Patient/[id]&code=http://snomed.info/sct|304686002,153851000146100,395091006,340171000146104,247751003,570801000146104
 
 6 GET [base]/DeviceUseStatement?patient=Patient/[id]&device.type=http://snomed.info/sct|72506001,465460004,468542000,704707009,1263462004,1236894001&_include=DeviceUseStatement:device
 

--- a/input/pagecontent/data-exchange.md
+++ b/input/pagecontent/data-exchange.md
@@ -59,7 +59,7 @@ The below listed search requests show how all the ACP agreements, procedural inf
 2. Retrieves `Consent` resources for Treatment Directives and includes the agreement parties (Patient, ContactPersons, and HealthProfessionals).
 3. Retrieves `Consent` resources for Advance Directives and includes the representatives (ContactPersons).
 4. Retrieves `Goal` resources related to advance care planning.
-5. Retrieves `Observation` resources related to specific wishes and plans, as defined by the profiles in the Implementation Guide.
+5. Retrieves `Observation` resources related to specific wishes, plans and whether the patient is legally capable, as defined by the profiles in the Implementation Guide.
 6. Retrieves `DeviceUseStatement` resources for devices representing an ICD, and includes the corresponding `Device` resource.
 7. Retrieves `CommunicationRequest` resources representing all communication requests related to the ACP procedure.
 

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -207,6 +207,7 @@ groups:
     name: "Structures: Resource Profiles"
     description: These are ACP profiles based on FHIR core resources.
     resources:
+    - StructureDefinition/ACP-LegallyCapable
     - StructureDefinition/ACP-InformRelativesRequest
     - StructureDefinition/ACP-MedicalPolicyGoal
     - StructureDefinition/ACP-OrganDonationChoiceRegistration


### PR DESCRIPTION
Draft PR to change the modelling of the legally capable indicator. Fixes https://github.com/IKNL/PZP-FHIR-R4/issues/137
Observation is now added, I think it should become something like this.

Things that need to be done:
- Remove extension for legally capable
- ~~Add correct snomed code (and remove current code) once available~~ - **done**
- Check/change descriptions and naming
- Update mermaid diagram and mappings (also depending on whether or not dataset will be changed)
- ~~Consider if we want to add a Flag with supporting info reference to this observation~~ - **Not for now**
- Update STU3 transformation scripts 