### PR TITLE
Add and couple ValueSet for procedure codes and update query

### DIFF
--- a/input/fsh/Alias.fsh
+++ b/input/fsh/Alias.fsh
@@ -1,5 +1,7 @@
 Alias: $snomed = http://snomed.info/sct
 Alias: $v3-NullFlavor = http://terminology.hl7.org/CodeSystem/v3-NullFlavor
+Alias: $DHD-CBV = urn:oid:2.16.840.1.113883.2.4.3.120.5.3
+Alias: $NZa = urn:oid:2.16.840.1.113883.2.4.3.27.15.5
 Alias: $DataAbsentReason = http://terminology.hl7.org/CodeSystem/data-absent-reason
 Alias: $v2-0203 = http://terminology.hl7.org/CodeSystem/v2-0203
 Alias: $v3-RoleCode = http://terminology.hl7.org/CodeSystem/v3-RoleCode

--- a/input/fsh/Procedure.fsh
+++ b/input/fsh/Procedure.fsh
@@ -6,8 +6,8 @@ Description: "Advance Care Planning procedure. Based on nl-core-Procedure-event 
 * insert MetaRules
 * subject only Reference(ACPPatient)
 * encounter only Reference(ACPEncounter)
+* code from ACPProcedureTypeVS (required)
 * code 1..1
-* code = $snomed#713603004
 
 * insert ObligationRules(subject)
 * insert ObligationRules(encounter)
@@ -60,7 +60,7 @@ Usage: #example
 * performer[=].actor.type = "Patient" 
 * performedPeriod.start = "2025-08-07"
 * performedPeriod.end = "2025-08-07"
-* code = $snomed#713603004 "advance care planning"
+* code = $DHD-CBV#411600B "PROACTIEVE ZORGPLANNING-OPSTEL. INDIV.ZORGPL.PALLIAT.FASE"
 
 Instance: ACP-Procedure-2-Pat2
 InstanceOf: ACPProcedure
@@ -79,4 +79,4 @@ Usage: #example
 * performer[=].actor.type = "Patient" 
 * performedPeriod.start = "2024-07-28"
 * performedPeriod.end = "2024-07-28"
-* code = $snomed#713603004 "advance care planning"
+* code = $NZa#190099 "Proactieve zorgplanning"

--- a/input/fsh/ValueSet.fsh
+++ b/input/fsh/ValueSet.fsh
@@ -223,7 +223,7 @@ Description: "ValueSet representing 'Yes, No, Unknown' answers."
 ValueSet: ACPProcedureTypeVS
 Id: ACP-ProcedureType
 Title: "ACP ProcedureType"
-Description: "ValueSet for ProcedureType, representing allowed codes for the ACP conversation. The DHD Verrichtingenthesaurus code `0000106562` (proactieve zorgplanning in palliatieve fase) is not included in this ValueSet, as this set is not meant to be used for exchange (see [ZIB-1233](https://nictiz.atlassian.net/browse/ZIB-1233))"
+Description: "ValueSet for ProcedureType, representing allowed codes for the ACP conversation. The DHD Verrichtingenthesaurus code `0000106562` (proactieve zorgplanning in palliatieve fase) is not included in this ValueSet, as this set is not meant to be used for exchange (see [ZIB-1233](https://nictiz.atlassian.net/browse/ZIB-1233)). The included SNOMED code is part of the referentieset of the DHD Verrichtingenthesaurus."
 * insert MetaRules
 * ^copyright = "This artefact includes content from SNOMED Clinical Terms® (SNOMED CT®) which is copyright of the International Health Terminology Standards Development Organisation (IHTSDO). Implementers of these artefacts must have the appropriate SNOMED CT Affiliate license - for more information contact http://www.snomed.org/snomed-ct/getsnomed-ct or info@snomed.org."
 * $snomed#713603004 "advance care planning"

--- a/input/fsh/ValueSet.fsh
+++ b/input/fsh/ValueSet.fsh
@@ -218,3 +218,36 @@ Description: "ValueSet representing 'Yes, No, Unknown' answers."
 * $snomed#373067005 ^designation[+].language = #nl-NL
 * $snomed#373067005 ^designation[=].use = $snomed#900000000000013009 "Synonym"
 * $snomed#373067005 ^designation[=].value = "neen"
+
+
+ValueSet: ACPProcedureTypeVS
+Id: ACP-ProcedureType
+Title: "ACP ProcedureType"
+Description: "ValueSet for ProcedureType, representing allowed codes for the ACP conversation. The DHD Verrichtingenthesaurus code `0000106562` (proactieve zorgplanning in palliatieve fase) is not included in this ValueSet, as this set is not meant to be used for exchange (see [ZIB-1233](https://nictiz.atlassian.net/browse/ZIB-1233))"
+* insert MetaRules
+* ^copyright = "This artefact includes content from SNOMED Clinical Terms® (SNOMED CT®) which is copyright of the International Health Terminology Standards Development Organisation (IHTSDO). Implementers of these artefacts must have the appropriate SNOMED CT Affiliate license - for more information contact http://www.snomed.org/snomed-ct/getsnomed-ct or info@snomed.org."
+* $snomed#713603004 "advance care planning"
+* $snomed#713603004 ^designation[0].language = #en-US
+* $snomed#713603004 ^designation[=].use.system = "http://snomed.info/sct"
+* $snomed#713603004 ^designation[=].use = $snomed#900000000000013009 "Synonym"
+* $snomed#713603004 ^designation[=].use.display = "Synonym"
+* $snomed#713603004 ^designation[=].value = "Advance care planning (procedure)"
+* $snomed#713603004 ^designation[+].language = #en-US
+* $snomed#713603004 ^designation[=].use.system = "http://snomed.info/sct"
+* $snomed#713603004 ^designation[=].use = $snomed#900000000000013009 "Synonym"
+* $snomed#713603004 ^designation[=].use.display = "Synonym"
+* $snomed#713603004 ^designation[=].value = "Advance care planning"
+* $snomed#713603004 ^designation[+].language = #nl-NL
+* $snomed#713603004 ^designation[=].use = $snomed#900000000000013009 "Synonym"
+* $snomed#713603004 ^designation[=].use.display = "Synonym"
+* $snomed#713603004 ^designation[=].value = "advance care planning (verrichting)"
+* $snomed#713603004 ^designation[+].language = #nl-NL
+* $snomed#713603004 ^designation[=].use = $snomed#900000000000013009 "Synonym"
+* $snomed#713603004 ^designation[=].use.display = "Synonym"
+* $snomed#713603004 ^designation[=].value = "bespreken van wensen en behoeften voor toekomstige zorg"
+* $snomed#713603004 ^designation[+].language = #nl-NL
+* $snomed#713603004 ^designation[=].use = $snomed#900000000000013009 "Synonym"
+* $snomed#713603004 ^designation[=].use.display = "Synonym"
+* $snomed#713603004 ^designation[=].value = "advance care planning"
+* $DHD-CBV#411600B "PROACTIEVE ZORGPLANNING-OPSTEL. INDIV.ZORGPL.PALLIAT.FASE"
+* $NZa#190099 "Proactieve zorgplanning"

--- a/input/includes/fhir-data-exchange-individual-resources-mermaid-diagram.md
+++ b/input/includes/fhir-data-exchange-individual-resources-mermaid-diagram.md
@@ -11,7 +11,7 @@ sequenceDiagram
   
         par 
             %% 1. Procedures
-            C->>S: GET /Procedure?patient=Patient/[id]<br>&code=sct|713603004<br>&_include=Procedure:encounter
+            C->>S: GET /Procedure?patient=Patient/[id]<br>&code=http://snomed.info/sct|713603004,<br>urn:oid:2.16.840.1.113883.2.4.3.120.5.3|411600B,<br>urn:oid:2.16.840.1.113883.2.4.3.27.15.5|190099<br>&_include=Procedure:encounter
             activate S
             S-->>C: 200 OK: Bundle (Procedure + Encounter)
             deactivate S

--- a/input/pagecontent/data-exchange.md
+++ b/input/pagecontent/data-exchange.md
@@ -38,7 +38,7 @@ The below listed search requests show how all the ACP agreements, procedural inf
 ```
 1a GET [base]/Procedure?patient=Patient/[id]&code=http://snomed.info/sct|713603004,urn:oid:2.16.840.1.113883.2.4.3.120.5.3|411600B,urn:oid:2.16.840.1.113883.2.4.3.27.15.5|190099&_include=Procedure:encounter
 
-1b GET [base]/Encounter?patient=Patient/[id]&reason-reference:Procedure.code=http://snomed.info/sct|713603004&_include=Encounter:reason-reference
+1b GET [base]/Encounter?patient=Patient/[id]&reason-reference:Procedure.code=http://snomed.info/sct|713603004,urn:oid:2.16.840.1.113883.2.4.3.120.5.3|411600B,urn:oid:2.16.840.1.113883.2.4.3.27.15.5|190099&_include=Encounter:reason-reference
 
 2 GET [base]/Consent?patient=Patient/[id]&scope=http://terminology.hl7.org/CodeSystem/consentscope|treatment&category=http://snomed.info/sct|129125009&_include=Consent:actor
 

--- a/input/pagecontent/data-exchange.md
+++ b/input/pagecontent/data-exchange.md
@@ -36,7 +36,7 @@ This approach is useful for applications that need to query specific parts of a 
 The below listed search requests show how all the ACP agreements, procedural information and relevant clinical context can be retrieved. Information on individuals involved in the ACP process are referenced from these resources and can be retrieved using the `_include` statement as defined below, or by resolving the references. Standard FHIR rules apply on the search syntax. The <a href="CapabilityStatement-ACP-CapabilityStatementProvider.html">Provider CapabilityStatement</a> and <a href="CapabilityStatement-ACP-CapabilityStatementConsulter.html">Consulter CapabilityStatement</a> resources may provide a more structured overview of the below requirements.
 
 ```
-1a GET [base]/Procedure?patient=Patient/[id]&code=http://snomed.info/sct|713603004&_include=Procedure:encounter
+1a GET [base]/Procedure?patient=Patient/[id]&code=http://snomed.info/sct|713603004,urn:oid:2.16.840.1.113883.2.4.3.120.5.3|411600B,urn:oid:2.16.840.1.113883.2.4.3.27.15.5|190099&_include=Procedure:encounter
 
 1b GET [base]/Encounter?patient=Patient/[id]&reason-reference:Procedure.code=http://snomed.info/sct|713603004&_include=Encounter:reason-reference
 


### PR DESCRIPTION
ValueSet for Procedure.code is made with snomed, CBV and NZa code. DHD VT code is not included as it is stated that this set should not be used for exchange: "SNOMED CT - SNOMED CT: ^41000147108 | DHD Verrichtingenthesaurus-referentieset (was: DHD Verrichtingenthesaurus - Alle waarden met OID 2.16.840.1.113883.2.4.3.120.5.2. Deze set is echter niet direct bedoeld voor uitwisseling. Zie onder andere [ZIB-1233](https://bits.nictiz.nl/browse/ZIB-1233))" Search query is updated accordingly, and to test new modelling, the examples are changed. This can be undone after review.

Fixes #132