### PR TITLE
Update package to use fhir2.base.template

### DIFF
--- a/local-template/package/package.json
+++ b/local-template/package/package.json
@@ -6,8 +6,8 @@
   "description": "Sample Template - not intended for real use",
   "author": "http://hl7.org/fhir",
   "canonical": "http://github.com/HL7/ig-template-sample",
-  "base": "fhir.base.template",
+  "base": "fhir2.base.template",
   "dependencies": {
-    "fhir.base.template": "current"
+    "fhir2.base.template": "current"
   }
 }


### PR DESCRIPTION
Change local-template/package/package.json to reference fhir2.base.template instead of fhir.base.template for both the "base" field and the dependency. This switches the sample template to the FHIR2 base template.