### PR TITLE
Update Firely.Terminal action version to v0.8.16

### DIFF
--- a/.github/workflows/r4_firely_terminal.yaml
+++ b/.github/workflows/r4_firely_terminal.yaml
@@ -30,7 +30,7 @@ jobs:
           java-version: '21'
         
       - name: Firely.Terminal (GitHub Actions)
-        uses: FirelyTeam/firely-terminal-pipeline@v0.8.1
+        uses: FirelyTeam/firely-terminal-pipeline@v0.8.16
         with:
           PATH_TO_CONFORMANCE_RESOURCES: fsh-generated/resources
           PATH_TO_EXAMPLES: fsh-generated/resources


### PR DESCRIPTION
updated the firely terminal pipeline for the new java validator because of issues with the terminology server in the validation pipeline 