### PR TITLE
#175 #176 data exchange clarifications

### DIFF
--- a/input/pagecontent/data-exchange.md
+++ b/input/pagecontent/data-exchange.md
@@ -65,6 +65,11 @@ The below listed search requests show how all the ACP agreements, procedural inf
 
 For `RelatedPerson` and `Practitioner` there is no specific query as according to the model there are references made to these resources. If there is a legal representative we expect that to be present in `Patient.contact`. For related persons attending the encounter a reference is expected to be made in `Encounter.participant`.
 
+##### Distinguishing ICD deactivation from additional 'Other' treatment directives
+The treatment directive regarding ICD deactivation is represented as a treatment directive with code `Other`. The SNOMED CT code `400231000146108` for ICD deactivation cannot be communicated in a structured coding element as the treatment directive `provision.code` element is bound to the national _BehandelingCodelijst_.
+To enable consistent identification of this specific directive, systems are expected to use the SNOMED CT code `400231000146108` in the `provision.code.text` element. Receiving systems are expected to use this SNOMED CT code to map the received treatment directive to the dedicated ICD deactivation treatment directive field or functionality in their user interface. The SNOMED CT code itself should not be displayed to end users.
+This requirement applies only to the treatment directive regarding ICD deactivation and not to other treatment directives categorized as `Other`.
+
 #### Advanced Search Parameters Supported
 The queries above use several search parameter types and modifiers:
 * `_include`: Returns referenced resources in the same `Bundle`, reducing the need for additional API calls.

--- a/input/pagecontent/data-exchange.md
+++ b/input/pagecontent/data-exchange.md
@@ -70,6 +70,19 @@ The treatment directive regarding ICD deactivation is represented as a treatment
 To enable consistent identification of this specific directive, systems are expected to use the SNOMED CT code `400231000146108` in the `provision.code.text` element. Receiving systems are expected to use this SNOMED CT code to map the received treatment directive to the dedicated ICD deactivation treatment directive field or functionality in their user interface. The SNOMED CT code itself should not be displayed to end users.
 This requirement applies only to the treatment directive regarding ICD deactivation and not to other treatment directives categorized as `Other`.
 
+##### Mapping observation codes to ACP profiles
+The data model defines several `Observation` profiles, each constraining a specific ACP concept by fixing a SNOMED CT code in the `Observation.code` element. Client request 5 retrieves these Observations using a code-based search. To support consistent implementation, the association between the SNOMED CT codes and the ACP Observation profiles is made explicit in the table below.
+
+| SNOMED CT Code | ACP Profile |
+| --- | --- |
+| 665671000146101 | [ACP-LegallyCapableTreatmentDecisions](https://as-iknl-api-documentatie.azurewebsites.net/docs/pzp/r4/en/StructureDefinition-ACP-LegallyCapableTreatmentDecisions.html) |
+| 153851000146100 | [ACP-SpecificCareWishes](https://as-iknl-api-documentatie.azurewebsites.net/docs/pzp/r4/en/StructureDefinition-ACP-SpecificCareWishes.html) |
+| 395091006 | [ACP-PreferredPlaceOfDeath](https://as-iknl-api-documentatie.azurewebsites.net/docs/pzp/r4/en/StructureDefinition-ACP-PreferredPlaceOfDeath.html) |
+| 340171000146104 | [ACP-PositionRegardingEuthanasia](https://api.iknl.nl/docs/pzp/r4/StructureDefinition/ACP-PositionRegardingEuthanasia) |
+| 247751003 | [ACP-SenseOfPurpose](https://as-iknl-api-documentatie.azurewebsites.net/docs/pzp/r4/en/StructureDefinition-ACP-PositionRegardingEuthanasia.html) |
+| 570801000146104 | [ACP-OrganDonationChoiceRegistration](https://as-iknl-api-documentatie.azurewebsites.net/docs/pzp/r4/en/StructureDefinition-ACP-OrganDonationChoiceRegistration.html) |
+
+
 #### Advanced Search Parameters Supported
 The queries above use several search parameter types and modifiers:
 * `_include`: Returns referenced resources in the same `Bundle`, reducing the need for additional API calls.

--- a/input/pagecontent/data-exchange.md
+++ b/input/pagecontent/data-exchange.md
@@ -67,7 +67,7 @@ For `RelatedPerson` and `Practitioner` there is no specific query as according t
 
 ##### Distinguishing ICD deactivation from additional 'Other' treatment directives
 The treatment directive regarding ICD deactivation is represented as a treatment directive with code `Other`. The SNOMED CT code `400231000146108` for ICD deactivation cannot be communicated in a structured coding element as the treatment directive `provision.code` element is bound to the national _BehandelingCodelijst_.
-To enable consistent identification of this specific directive, systems are expected to use the SNOMED CT code `400231000146108` in the `provision.code.text` element. Receiving systems are expected to use this SNOMED CT code to map the received treatment directive to the dedicated ICD deactivation treatment directive field or functionality in their user interface. The SNOMED CT code itself should not be displayed to end users.
+To enable consistent identification of this specific directive, systems are expected to use the SNOMED CT code `400231000146108` in the `provision.code.text` element as demonstrated in this [example](https://as-iknl-api-documentatie.azurewebsites.net/docs/pzp/r4/en/Consent-ACP-TreatmentDirective-SwitchOffICD-Pat1.html). Receiving systems are expected to use this SNOMED CT code to map the received treatment directive to the dedicated ICD deactivation treatment directive field or functionality in their user interface. The SNOMED CT code itself should not be displayed to end users.
 This requirement applies only to the treatment directive regarding ICD deactivation and not to other treatment directives categorized as `Other`.
 
 ##### Mapping observation codes to ACP profiles


### PR DESCRIPTION
Added two sections on the data exchange page:

- Section 4.3.1.1 on how to handle the ICD deactivation treatment directive
- Section 4.3.1.2 on association between observation codes and observation profiles

When sections are agreed upon, they need to be added to stu3 IG as well.