### PR TITLE
Issue 144 obligations

### DIFF
--- a/input/fsh/CommunicationRequest.fsh
+++ b/input/fsh/CommunicationRequest.fsh
@@ -25,7 +25,6 @@ Description: "A CommunicationRequest representing the advice or instruction give
 * insert ObligationRules(authoredOn) // not explicitly required/defined in dataset but important for context
 * insert ObligationRules(requester)
 * insert ObligationRules(sender)
-* insert ObligationRules(recipient)
 * insert ObligationRules(reasonCode) // already 1..1 so may not be needed place under obligation but added for consistency
 
 

--- a/input/fsh/Observation.fsh
+++ b/input/fsh/Observation.fsh
@@ -130,7 +130,7 @@ Usage: #example
 
 Instance: ACP-PreferredPlaceOfDeath-Pat2
 InstanceOf: ACPPreferredPlaceOfDeath
-Title: "ACP Preferred Place Of Death - Pat 2"
+Title: "ACP Preferred Place of Death - Pat 2"
 Usage: #example
 * identifier.type = $v2-0203#RI "Resource identifier"
 * identifier.system = "https://acme.com/fhir/NamingSystem/resource-business-identifier"
@@ -141,8 +141,9 @@ Usage: #example
 * status = #final
 * code =  $snomed#395091006 "gewenste plek van overlijden"
 * effectiveDateTime = "2025-08-07"
-* valueCodeableConcept = $snomed#264362003 "thuis"
-* note.text = "Het liefst rustig thuis"
+* valueCodeableConcept = $v3-NullFlavor#OTH "Anders"
+* valueCodeableConcept.text = "bijna-thuis-huis"
+* note.text = "Het liefst in een bijna-thuis-huis in de buurt van haar kinderen"
 
 
 Profile: ACPPositionRegardingEuthanasia
@@ -270,7 +271,7 @@ Usage: #example
 
 Instance: ACP-OrganDonationChoiceRegistrationInDonorRegister-Pat2
 InstanceOf: ACPOrganDonationChoiceRegistration
-Title: "ACP Organ Donation Choice Registration In Donor Register - Pat 2"
+Title: "ACP Organ Donation Choice Registration in Donor Register - Pat 2"
 Usage: #example
 * identifier.type = $v2-0203#RI "Resource identifier"
 * identifier.system = "https://acme.com/fhir/NamingSystem/resource-business-identifier"

--- a/input/fsh/Observation.fsh
+++ b/input/fsh/Observation.fsh
@@ -141,9 +141,8 @@ Usage: #example
 * status = #final
 * code =  $snomed#395091006 "gewenste plek van overlijden"
 * effectiveDateTime = "2025-08-07"
-* valueCodeableConcept = $v3-NullFlavor#OTH "Anders"
-* valueCodeableConcept.text = "bijna-thuis-huis"
-* note.text = "Het liefst in een bijna-thuis-huis in de buurt van haar kinderen"
+* valueCodeableConcept = $snomed#264362003 "thuis"
+* note.text = "Het liefst rustig thuis"
 
 
 Profile: ACPPositionRegardingEuthanasia

--- a/input/fsh/RuleSet.fsh
+++ b/input/fsh/RuleSet.fsh
@@ -48,6 +48,7 @@ RuleSet: CapabilityStatementSearchParmeterClinicalPatientExpectation
   * type = #reference
 
 RuleSet: ObligationRules(path)
+* {path} MS
 * {path} ^extension[$obligation][+].extension[code].valueCode = #SHALL:populate-if-known
 * {path} ^extension[$obligation][=].extension[actor].valueCanonical = Canonical(ACPActorProvider)
 * {path} ^extension[$obligation][+].extension[code].valueCode = #SHALL:no-error

--- a/input/pagecontent/data-model.md
+++ b/input/pagecontent/data-model.md
@@ -23,7 +23,7 @@ The FHIR profiles in this guide are directly linked to the ACP dataset elements 
 
 Each StructureDefinition includes a `StructureDefinition.mapping.uri` that points to the specific version of the ACP dataset used. Additionally, every element within a profile is individually mapped to its corresponding dataset element using the `ElementDefinition.mapping` property. The mapping table below shows all mappings in one view, while the "Mappings" tab of each profile page displays the mappings consolidated per profile. These mappings provide a straightforward way to highlight the elements that are especially relevant for the ACP use case. 
 
-#### MustSupport and Obligations
+#### MustSupport and Obligation flags
 To indicate which elements are essential for the ACP use case and for which implementations must thus provide support, `mustSupport` flags are placed on all elements mapped to the ACP dataset. For clarification of the expectations associated with these `mustSupport` labels, the <a href="https://hl7.org/fhir/extensions/StructureDefinition-obligation.html">`obligation` element</a> is used.
 
 In this version of the IG, `mustSupport` and `obligation` flags are applied to all mapped elements, regardless of whether the dataset element is mandatory or optional. The `obligations` are defined for the following actors:

--- a/input/pagecontent/data-model.md
+++ b/input/pagecontent/data-model.md
@@ -23,14 +23,14 @@ The FHIR profiles in this guide are directly linked to the ACP dataset elements 
 
 Each StructureDefinition includes a `StructureDefinition.mapping.uri` that points to the specific version of the ACP dataset used. Additionally, every element within a profile is individually mapped to its corresponding dataset element using the `ElementDefinition.mapping` property. The mapping table below shows all mappings in one view, while the "Mappings" tab of each profile page displays the mappings consolidated per profile. These mappings provide a straightforward way to highlight the elements that are especially relevant for the ACP use case. 
 
-#### Obligation flags
-To indicate which elements are essential for the ACP use case, <a href="https://hl7.org/fhir/extensions/StructureDefinition-obligation.html">Obligation flags</a> have been added to all elements mapped to the ACP dataset. These flags are visible in the formal profile views.
+#### MustSupport and Obligations
+To indicate which elements are essential for the ACP use case and for which implementations must thus provide support, `mustSupport` flags are placed on all elements mapped to the ACP dataset. For clarification of the expectations associated with these `mustSupport` labels, the <a href="https://hl7.org/fhir/extensions/StructureDefinition-obligation.html">`obligation` element</a> is used.
 
-In this version of the IG, Obligation flags are applied to all mapped elements, regardless of whether the dataset element is mandatory or optional. The obligations are defined for the following actors:
+In this version of the IG, `mustSupport` and `obligation` flags are applied to all mapped elements, regardless of whether the dataset element is mandatory or optional. The `obligations` are defined for the following actors:
 * <a href="ActorDefinition-ACPActorProvider.html">ACP Actor Provider</a>: `SHALL:populate-if-known`
 * <a href="ActorDefinition-ACPActorConsulter.html">ACP Actor Consulter</a>: `SHALL:no-error`
 
-In future versions of the IG, these obligations may be refined on a per-element basis.
+In future versions of the IG, these `obligations` may be refined on a per-element basis.
 
 #### Note on referenced zibs
 


### PR DESCRIPTION
- We will add must support to all elements with obligations. The obligation functions as a clarification of the must support. --> done
- We will add must support and obligation on value.text for values where other is an option (e.g. preferred place of death). --> not done yet, seems like we first have to remove/change this: _* value[x] only CodeableConcept_
- We will remove the obligation from the recipient in the InformRelativesRequest profile. --> done