### PR TITLE
Homepage, internal referencing and url information standard

### DIFF
--- a/input/pagecontent/data-exchange.md
+++ b/input/pagecontent/data-exchange.md
@@ -67,7 +67,7 @@ For `RelatedPerson` and `Practitioner` there is no specific query as according t
 
 ##### Distinguishing ICD deactivation from additional 'Other' treatment directives
 The treatment directive regarding ICD deactivation is represented as a treatment directive with code `Other`. The SNOMED CT code `400231000146108` for ICD deactivation cannot be communicated in a structured coding element as the treatment directive `provision.code` element is bound to the national _BehandelingCodelijst_.
-To enable consistent identification of this specific directive, systems are expected to use the SNOMED CT code `400231000146108` in the `provision.code.text` element as demonstrated in this [example](https://as-iknl-api-documentatie.azurewebsites.net/docs/pzp/r4/en/Consent-ACP-TreatmentDirective-SwitchOffICD-Pat1.html). Receiving systems are expected to use this SNOMED CT code to map the received treatment directive to the dedicated ICD deactivation treatment directive field or functionality in their user interface. The SNOMED CT code itself should not be displayed to end users.
+To enable consistent identification of this specific directive, systems are expected to use the SNOMED CT code `400231000146108` in the `provision.code.text` element as demonstrated in this <a href="Consent-ACP-TreatmentDirective-SwitchOffICD-Pat1.html">Example</a>. Receiving systems are expected to use this SNOMED CT code to map the received treatment directive to the dedicated ICD deactivation treatment directive field or functionality in their user interface. The SNOMED CT code itself should not be displayed to end users.
 This requirement applies only to the treatment directive regarding ICD deactivation and not to other treatment directives categorized as `Other`.
 
 ##### Mapping observation codes to ACP profiles
@@ -75,12 +75,12 @@ The data model defines several `Observation` profiles, each constraining a speci
 
 | SNOMED CT Code | ACP Profile |
 | --- | --- |
-| 665671000146101 | [ACP-LegallyCapableTreatmentDecisions](https://as-iknl-api-documentatie.azurewebsites.net/docs/pzp/r4/en/StructureDefinition-ACP-LegallyCapableTreatmentDecisions.html) |
-| 153851000146100 | [ACP-SpecificCareWishes](https://as-iknl-api-documentatie.azurewebsites.net/docs/pzp/r4/en/StructureDefinition-ACP-SpecificCareWishes.html) |
-| 395091006 | [ACP-PreferredPlaceOfDeath](https://as-iknl-api-documentatie.azurewebsites.net/docs/pzp/r4/en/StructureDefinition-ACP-PreferredPlaceOfDeath.html) |
-| 340171000146104 | [ACP-PositionRegardingEuthanasia](https://api.iknl.nl/docs/pzp/r4/StructureDefinition/ACP-PositionRegardingEuthanasia) |
-| 247751003 | [ACP-SenseOfPurpose](https://as-iknl-api-documentatie.azurewebsites.net/docs/pzp/r4/en/StructureDefinition-ACP-PositionRegardingEuthanasia.html) |
-| 570801000146104 | [ACP-OrganDonationChoiceRegistration](https://as-iknl-api-documentatie.azurewebsites.net/docs/pzp/r4/en/StructureDefinition-ACP-OrganDonationChoiceRegistration.html) |
+| 665671000146101 | <a href="StructureDefinition-ACP-LegallyCapableTreatmentDecisions.html">ACP-LegallyCapableTreatmentDecisions</a> |
+| 153851000146100 | <a href="StructureDefinition-ACP-SpecificCareWishes.html">ACP-SpecificCareWishes</a> |
+| 395091006 | <a href="StructureDefinition-ACP-PreferredPlaceOfDeath.html">ACP-PreferredPlaceOfDeath</a> |
+| 340171000146104 | <a href="StructureDefinition-ACP-PositionRegardingEuthanasia.html">ACP-PositionRegardingEuthanasia</a> |
+| 247751003 | <a href="StructureDefinition-ACP-SenseOfPurpose.html">ACP-SenseOfPurpose</a> |
+| 570801000146104 | <a href="StructureDefinition-ACP-OrganDonationChoiceRegistration.html">ACP-OrganDonationChoiceRegistration</a> |
 
 
 #### Advanced Search Parameters Supported

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -10,6 +10,17 @@ This guide assumes that readers are familiar with the functional specifications 
 You are currently viewing the <strong>FHIR R4</strong> version of the IG for the ACP information standard.  
 If you are looking for the <strong>STU3</strong> version, you can find it here: <a href="https://api.iknl.nl/docs/pzp/stu3/">Advance Care Planning STU3 HCIM 2017.</a>
 
+### How to Read this Guide
+This guide is divided into several pages which are listed at the top of each page in the menu bar. 
+
+* [Home](index.html): This page provides the introduction and scope of this implementation guide. 
+* [Information Standard](information-standard.html): This page describes the documents that together comprise the ACP information standard. 
+* [Data Model](data-model.html): This page provides an overview of the FHIR profiles used to represent the ACP dataset and includes mappings between the dataset and FHIR artifacts.
+* [Data Exchange](data-exchange.html): This page describes the two transaction methods for exchanging a patient's Advance Care Planning (ACP) information using RESTful API and includes the client requests that can be used to retrieve the ACP information. 
+* [Artifacts](artifacts.html): This page provides a list of the FHIR artifacts defined as part of this implementation guide, including actor definitions, profiles, value sets, examples, questionnaires, questionnaire responses and capability statements.
+* [Change Log](changelog.html):This page summarizes changes introduced in each published release of the implementation guide.
+* [Downloads](downloads.html): This page provides links to downloadable artifacts.
+
 ### Dependencies
 
 {% include dependency-table.xhtml %}

--- a/input/pagecontent/information-standard.md
+++ b/input/pagecontent/information-standard.md
@@ -13,7 +13,7 @@ The functional design forms the basis for this IG. It entails:
 - A description of the envisioned infrastructure for ACP data exchange;
 - An overview of involved parties and their corresponding roles.
 
-[Functioneel Ontwerp](https://palliaweb.nl/overzichtspagina-hulpmiddelen/uniform-vastleggen-proactieve-zorgplanning-2026)  
+[Functioneel Ontwerp](https://iknl.nl/palliatieve-zorg/informatiestandaard-proactieve-zorgplanning)  
 
 ##### Datasets, Terminology and scenarios 
 Inside the functional design there are links directing to [ART-DECOR](https://decor.nictiz.nl/ad/#/pall-izppz-/project/overview).
@@ -36,7 +36,7 @@ It describes how the ACP information standard is specifically implemented in HL7
 To ensure correct implementation and interoperability, test data are provided.  
 These artefacts support vendors and implementers in validating their systems against the requirements defined in the functional and technical design.
 
-[Testscripts](https://palliaweb.nl/overzichtspagina-hulpmiddelen/uniform-vastleggen-proactieve-zorgplanning-2026)
+[Testscripts](https://iknl.nl/palliatieve-zorg/informatiestandaard-proactieve-zorgplanning)
 
 
 


### PR DESCRIPTION
Added a 'how to read this guide' section to the homepage inspired by AU and US core. Additionally, references to static IG pages are replaced by dynamic references and the new url for the information standard is used in references.